### PR TITLE
Set up Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/laravel"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "php"
+
+  - package-ecosystem: "npm"
+    directory: "/laravel"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "ci"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly Monday updates for Composer, pnpm, and GitHub Actions
- Creates labels: `dependencies`, `php`, `javascript`, `ci`
- Limits to 5 open PRs per ecosystem to avoid noise

## Test plan
- [x] `dependabot.yml` committed
- [ ] Verify Dependabot is active under **Insights → Dependency graph → Dependabot**
- [ ] Confirm first batch of PRs arrives within a week

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)