### PR TITLE
feat: set up Ziggy for Laravel route helpers in Vue (#7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,10 @@ Browser → Laravel `routes/web.php` → Controller calls `Inertia::render('Fold
 - **Path alias**: `@/` resolves to `resources/js/` (configured in both `tsconfig.json` and `vite.config.ts`).
 - **Testing**: Vitest + `@vue/test-utils` for unit/component tests (co-located as `*.spec.ts`); Cypress for e2e (requires `php artisan serve` running).
 
+## Tracking Progress
+
+Just before opening a pull request for an issue, update `plan.md` by changing the status indicator for that issue from ⬜ to ✅ and include that change in the same commit.
+
 ## Git Workflow
 
 This project follows **GitHub Flow**: one branch per feature/fix, PR into `main`, merge after CI passes.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/Three-Hoops/Hoops-CMS/actions/workflows/ci.yml/badge.svg)](https://github.com/Three-Hoops/Hoops-CMS/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/Three-Hoops/Hoops-CMS/actions/workflows/codeql.yml/badge.svg)](https://github.com/Three-Hoops/Hoops-CMS/actions/workflows/codeql.yml)
 
-A fully-featured, reusable CMS starter built on **Laravel 13**, **Vue 3**, and **Inertia.js v2**. Drop it into a new project and get a production-ready admin panel with content management, media library, user management, multilingual support, theming, and a headless API — without writing any of the boilerplate yourself.
+A fully-featured, reusable CMS starter built on **Laravel 13**, **Vue 3**, and **Inertia.js v3**. Drop it into a new project and get a production-ready admin panel with content management, media library, user management, multilingual support, theming, and a headless API — without writing any of the boilerplate yourself.
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
-        "inertiajs/inertia-laravel": "^3.0"
+        "inertiajs/inertia-laravel": "^3.0",
+        "tightenco/ziggy": "^2.6"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a9d75cf9e70d2a0edce49bce30c3b4e",
+    "content-hash": "cd1d089722fad95d30eb359872a25439",
     "packages": [
         {
             "name": "brick/math",
@@ -5539,6 +5539,76 @@
                 }
             ],
             "time": "2026-03-31T07:15:36+00:00"
+        },
+        {
+            "name": "tightenco/ziggy",
+            "version": "v2.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tighten/ziggy.git",
+                "reference": "8a0b645921623f77dceaf543d61ecd51a391d96e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tighten/ziggy/zipball/8a0b645921623f77dceaf543d61ecd51a391d96e",
+                "reference": "8a0b645921623f77dceaf543d61ecd51a391d96e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "laravel/framework": ">=9.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "laravel/folio": "^1.1",
+                "orchestra/testbench": "^8.0 || ^9.0 || ^10.0",
+                "pestphp/pest": "^2.0 || ^3.0 || ^4.0",
+                "pestphp/pest-plugin-laravel": "^2.0 || ^3.0 || ^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Tighten\\Ziggy\\ZiggyServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Tighten\\Ziggy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Coulbourne",
+                    "email": "daniel@tighten.co"
+                },
+                {
+                    "name": "Jake Bathman",
+                    "email": "jake@tighten.co"
+                },
+                {
+                    "name": "Jacob Baker-Kretzmar",
+                    "email": "jacob@tighten.co"
+                }
+            ],
+            "description": "Use your Laravel named routes in JavaScript.",
+            "homepage": "https://github.com/tighten/ziggy",
+            "keywords": [
+                "Ziggy",
+                "javascript",
+                "laravel",
+                "routes"
+            ],
+            "support": {
+                "issues": "https://github.com/tighten/ziggy/issues",
+                "source": "https://github.com/tighten/ziggy/tree/v2.6.2"
+            },
+            "time": "2026-03-05T14:41:19+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",

--- a/laravel/package.json
+++ b/laravel/package.json
@@ -28,7 +28,8 @@
     "pinia": "^3.0.4",
     "reka-ui": "^2.9.6",
     "tailwind-merge": "^3.5.0",
-    "vue": "^3.5.0"
+    "vue": "^3.5.0",
+    "ziggy-js": "^2.6.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/laravel/pnpm-lock.yaml
+++ b/laravel/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       vue:
         specifier: ^3.5.0
         version: 3.5.32(typescript@6.0.3)
+      ziggy-js:
+        specifier: ^2.6.2
+        version: 2.6.2
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -2148,6 +2151,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs-esm@7.0.3:
+    resolution: {integrity: sha512-8jbjCR0PPbqoQcv83C2K/zvVeytRPwPpt3WPDbq51qyLAxcWGtXVRjSe6GHtLCoVbg9+NEFkv7GyUxqjcDIJzw==}
+    engines: {node: '>=18'}
+
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
     engines: {node: '>=0.6'}
@@ -2725,6 +2732,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  ziggy-js@2.6.2:
+    resolution: {integrity: sha512-41xc9wRvv5Olh8pZjKSaL5vDAjw4BfTDMFoeLwRpDGc2B+uqcdwIKd81EHs6uwpqahdRrU7uMab0xWj0hBSDjg==}
 
 snapshots:
 
@@ -4674,6 +4684,8 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs-esm@7.0.3: {}
+
   qs@6.14.2:
     dependencies:
       side-channel: 1.1.0
@@ -5248,3 +5260,7 @@ snapshots:
       fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
+
+  ziggy-js@2.6.2:
+    dependencies:
+      qs-esm: 7.0.3

--- a/laravel/resources/js/app.ts
+++ b/laravel/resources/js/app.ts
@@ -1,6 +1,7 @@
 import { createApp, h, DefineComponent } from 'vue'
 import { createInertiaApp } from '@inertiajs/vue3'
 import { createPinia } from 'pinia'
+import { ZiggyVue } from 'ziggy-js'
 import '../css/app.css'
 
 createInertiaApp({
@@ -12,6 +13,7 @@ createInertiaApp({
         createApp({ render: () => h(App, props) })
             .use(plugin)
             .use(createPinia())
+            .use(ZiggyVue)
             .mount(el)
     },
 })

--- a/laravel/resources/views/app.blade.php
+++ b/laravel/resources/views/app.blade.php
@@ -4,6 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title inertia>{{ config('app.name') }}</title>
+        @routes
         @vite(['resources/css/app.css', 'resources/js/app.ts'])
         @inertiaHead
     </head>

--- a/package.json
+++ b/package.json
@@ -14,10 +14,15 @@
   "dependencies": {
     "@inertiajs/vue3": "^2.0.0",
     "pinia": "^2.3.0",
-    "vue": "^3.5.0"
+    "vue": "^3.5.0",
+    "ziggy-js": "^2.6.2"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["cypress", "esbuild", "vue-demi"]
+    "onlyBuiltDependencies": [
+      "cypress",
+      "esbuild",
+      "vue-demi"
+    ]
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.0",

--- a/plan.md
+++ b/plan.md
@@ -26,7 +26,7 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 | ✅ | [#34](https://github.com/Three-Hoops/Hoops-CMS/issues/34) | Set up Dependabot for automated dependency updates | `infrastructure` |
 | ✅ | [#48](https://github.com/Three-Hoops/Hoops-CMS/issues/48) | Add .env.testing for the test environment | `testing` |
 | ✅ | [#5](https://github.com/Three-Hoops/Hoops-CMS/issues/5) | Add shadcn-vue component library | `developer-experience` |
-| ⬜ | [#7](https://github.com/Three-Hoops/Hoops-CMS/issues/7) | Set up Ziggy for Laravel route helpers in Vue | `developer-experience` |
+| ✅ | [#7](https://github.com/Three-Hoops/Hoops-CMS/issues/7) | Set up Ziggy for Laravel route helpers in Vue | `developer-experience` |
 | ⬜ | [#59](https://github.com/Three-Hoops/Hoops-CMS/issues/59) | Add laravel-ide-helper for IDE autocompletion | `developer-experience` |
 | ⬜ | [#96](https://github.com/Three-Hoops/Hoops-CMS/issues/96) | Enable Model::preventLazyLoading() to catch N+1 queries | `performance`, `developer-experience` |
 | ⬜ | [#102](https://github.com/Three-Hoops/Hoops-CMS/issues/102) | Add Vite bundle analyser | `performance`, `developer-experience` |

--- a/plan.md
+++ b/plan.md
@@ -25,7 +25,7 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 | ✅ | [#90](https://github.com/Three-Hoops/Hoops-CMS/issues/90) | Add dependency vulnerability scanning to CI pipeline | `security`, `infrastructure` |
 | ✅ | [#34](https://github.com/Three-Hoops/Hoops-CMS/issues/34) | Set up Dependabot for automated dependency updates | `infrastructure` |
 | ✅ | [#48](https://github.com/Three-Hoops/Hoops-CMS/issues/48) | Add .env.testing for the test environment | `testing` |
-| ⬜ | [#5](https://github.com/Three-Hoops/Hoops-CMS/issues/5) | Add shadcn-vue component library | `developer-experience` |
+| ✅ | [#5](https://github.com/Three-Hoops/Hoops-CMS/issues/5) | Add shadcn-vue component library | `developer-experience` |
 | ⬜ | [#7](https://github.com/Three-Hoops/Hoops-CMS/issues/7) | Set up Ziggy for Laravel route helpers in Vue | `developer-experience` |
 | ⬜ | [#59](https://github.com/Three-Hoops/Hoops-CMS/issues/59) | Add laravel-ide-helper for IDE autocompletion | `developer-experience` |
 | ⬜ | [#96](https://github.com/Three-Hoops/Hoops-CMS/issues/96) | Enable Model::preventLazyLoading() to catch N+1 queries | `performance`, `developer-experience` |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       vue:
         specifier: ^3.5.0
         version: 3.5.32(typescript@5.9.3)
+      ziggy-js:
+        specifier: ^2.6.2
+        version: 2.6.2
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^5.2.0
@@ -1250,6 +1253,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs-esm@7.0.3:
+    resolution: {integrity: sha512-8jbjCR0PPbqoQcv83C2K/zvVeytRPwPpt3WPDbq51qyLAxcWGtXVRjSe6GHtLCoVbg9+NEFkv7GyUxqjcDIJzw==}
+    engines: {node: '>=18'}
+
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
     engines: {node: '>=0.6'}
@@ -1642,6 +1649,9 @@ packages:
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
+  ziggy-js@2.6.2:
+    resolution: {integrity: sha512-41xc9wRvv5Olh8pZjKSaL5vDAjw4BfTDMFoeLwRpDGc2B+uqcdwIKd81EHs6uwpqahdRrU7uMab0xWj0hBSDjg==}
 
 snapshots:
 
@@ -2806,6 +2816,8 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs-esm@7.0.3: {}
+
   qs@6.14.2:
     dependencies:
       side-channel: 1.1.0
@@ -3196,3 +3208,7 @@ snapshots:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+
+  ziggy-js@2.6.2:
+    dependencies:
+      qs-esm: 7.0.3


### PR DESCRIPTION
## Summary
- Installs `tightenco/ziggy` via Composer and `ziggy-js` via pnpm
- Adds `@routes` directive to `app.blade.php` (injects route list as JSON)
- Registers `ZiggyVue` plugin in `app.ts` so `route()` is available globally
- Marks #5 as done in `plan.md`

Usage in any Vue component or Inertia form:
\`\`\`ts
import { route } from 'ziggy-js'
form.post(route('admin.posts.store'))
\`\`\`

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)