### PR TITLE
Make admin layout mobile-responsive (#82)

### DIFF
--- a/.claude/projects/-Users-alexverbraecken-Documents-GitHub-Hoops-CMS/memory/MEMORY.md
+++ b/.claude/projects/-Users-alexverbraecken-Documents-GitHub-Hoops-CMS/memory/MEMORY.md
@@ -3,3 +3,4 @@
 - [Plan review workflow](feedback_plan_workflow.md) — Wait for user to read plan before implementing; proceed one phase at a time
 - [GitHub issue creation](feedback_github_issues.md) — No confirmation needed before creating GitHub issues; proceed directly
 - [withoutVite() in feature tests](feedback_testing_withoutVite.md) — Any test calling assertInertia() must use $this->withoutVite() to avoid CI failures
+- [Test file naming and AAA pattern](feedback_test_conventions.md) — Vue/TS tests use .test.ts and Arrange/Act/Assert comments

--- a/.claude/projects/-Users-alexverbraecken-Documents-GitHub-Hoops-CMS/memory/feedback_test_conventions.md
+++ b/.claude/projects/-Users-alexverbraecken-Documents-GitHub-Hoops-CMS/memory/feedback_test_conventions.md
@@ -1,0 +1,26 @@
+---
+name: Test file naming and AAA pattern
+description: Vue/TS test files must use .test.ts extension and follow Arrange/Act/Assert pattern
+type: feedback
+---
+
+Always name Vue/TypeScript test files `*.test.ts` (never `*.spec.ts`).
+
+All tests must follow the **Arrange / Act / Assert** pattern with inline comments:
+
+```ts
+it('does something', () => {
+    // Arrange
+    const wrapper = mount(MyComponent)
+
+    // Act
+    await wrapper.find('button').trigger('click')
+
+    // Assert
+    expect(wrapper.find('.result').text()).toBe('done')
+})
+```
+
+**Why:** Agreed convention with the user — consistent naming and structure across all tests.
+
+**How to apply:** Every new `it()` block gets the three comment sections. If there is no Act step (e.g. pure environment checks), note it inline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Browser → Laravel `routes/web.php` → Controller calls `Inertia::render('Fold
 - **State**: Pinia stores in `resources/js/stores/`. Global shared state (auth user, flash messages) goes through `HandleInertiaRequests::share()`.
 - **Styling**: Tailwind CSS v4 via `@tailwindcss/vite` plugin.
 - **Path alias**: `@/` resolves to `resources/js/` (configured in both `tsconfig.json` and `vite.config.ts`).
-- **Testing**: Vitest + `@vue/test-utils` for unit/component tests (co-located as `*.spec.ts`); Cypress for e2e (requires `php artisan serve` running). **Always write tests when implementing new functionality** — see Testing Rules below.
+- **Testing**: Vitest + `@vue/test-utils` for unit/component tests (co-located as `*.test.ts`); Cypress for e2e (requires `php artisan serve` running). **Always write tests when implementing new functionality** — see Testing Rules below.
 - **Lazy loading**: `Model::preventLazyLoading()` is active in all non-production environments. If you see a `LazyLoadingViolationException`, fix it by eager-loading the relationship in the controller: `Post::with(['category', 'tags'])->paginate()`.
 - **Vue SFC order**: always `<script setup lang="ts">` first, then `<template>`, then `<style>` (if needed). Never use Options API.
 
@@ -104,12 +104,29 @@ Run: `php artisan test` (uses `.env.testing` automatically)
 
 | What you're adding | Test type | Location |
 |--------------------|-----------|----------|
-| Component with logic | Component test (`*.spec.ts` co-located) | Mount with `@vue/test-utils`, assert rendered output + emits |
-| Pinia store | Unit test (`stores/*.spec.ts`) | Test actions/getters in isolation |
-| Composable | Unit test (`composables/*.spec.ts`) | Call and assert return values |
+| Component with logic | Component test (`*.test.ts` co-located) | Mount with `@vue/test-utils`, assert rendered output + emits |
+| Pinia store | Unit test (`stores/*.test.ts`) | Test actions/getters in isolation |
+| Composable | Unit test (`composables/*.test.ts`) | Call and assert return values |
 | Full user flow | Cypress e2e (`cypress/e2e/`) | Only for critical happy paths |
 
 Run: `pnpm test` (Vitest) or `pnpm test:e2e` (Cypress)
+
+### Test structure
+
+All tests must follow the **Arrange / Act / Assert** pattern with inline comments:
+
+```ts
+it('does something', () => {
+    // Arrange
+    const wrapper = mount(MyComponent)
+
+    // Act
+    await wrapper.find('button').trigger('click')
+
+    // Assert
+    expect(wrapper.find('.result').text()).toBe('done')
+})
+```
 
 ### When NOT to write a test
 

--- a/laravel/package.json
+++ b/laravel/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@pinia/testing": "^1.0.3",
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^6.0.0",
     "@vitest/coverage-v8": "^3.2.4",

--- a/laravel/pnpm-lock.yaml
+++ b/laravel/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.0(jiti@2.6.1))
+      '@pinia/testing':
+        specifier: ^1.0.3
+        version: 1.0.3(pinia@3.0.4(typescript@6.0.3)(vue@3.5.32(typescript@6.0.3)))
       '@tailwindcss/vite':
         specifier: ^4.0.0
         version: 4.2.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
@@ -499,6 +502,11 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       vue: '>=3.2.39'
+
+  '@pinia/testing@1.0.3':
+    resolution: {integrity: sha512-g+qR49GNdI1Z8rZxKrQC3GN+LfnGTNf5Kk8Nz5Cz6mIGva5WRS+ffPXQfzhA0nu6TveWzPNYTjGl4nJqd3Cu9Q==}
+    peerDependencies:
+      pinia: '>=3.0.4'
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -3213,6 +3221,10 @@ snapshots:
   '@phosphor-icons/vue@2.2.1(vue@3.5.32(typescript@6.0.3))':
     dependencies:
       vue: 3.5.32(typescript@6.0.3)
+
+  '@pinia/testing@1.0.3(pinia@3.0.4(typescript@6.0.3)(vue@3.5.32(typescript@6.0.3)))':
+    dependencies:
+      pinia: 3.0.4(typescript@6.0.3)(vue@3.5.32(typescript@6.0.3))
 
   '@pkgjs/parseargs@0.11.0':
     optional: true

--- a/laravel/resources/js/Layouts/AdminLayout.spec.ts
+++ b/laravel/resources/js/Layouts/AdminLayout.spec.ts
@@ -1,0 +1,96 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import AdminLayout from './AdminLayout.vue'
+
+const currentUrl = ref('/admin')
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({
+        get url() { return currentUrl.value },
+        props: {
+            app: { name: 'Hoops CMS' },
+            auth: { name: 'Admin', role: 'super_admin', last_login_at: null },
+            flash: { success: null, error: null },
+            ziggy: { location: 'http://localhost', routes: {} },
+        },
+    }),
+    useForm: () => ({ post: vi.fn(), processing: false }),
+    Link: { template: '<a><slot /></a>' },
+}))
+
+vi.mock('ziggy-js', () => ({
+    route: (name: string) => `/${name}`,
+}))
+
+vi.mock('@/components/Admin/FlashBanner.vue', () => ({
+    default: { template: '<div />' },
+}))
+
+vi.mock('@/stores/useAuthStore', () => ({
+    useAuthStore: () => ({
+        user: { name: 'Admin', role: 'super_admin', last_login_at: null },
+    }),
+}))
+
+const globalConfig = {
+    global: {
+        plugins: [],
+        mocks: { $page: { url: '/admin' } },
+        stubs: { Link: { template: '<a><slot /></a>' } },
+    },
+    slots: { default: '<div />' },
+}
+
+describe('AdminLayout', () => {
+    beforeEach(() => {
+        currentUrl.value = '/admin'
+    })
+
+    it('hides the sidebar by default', () => {
+        const wrapper = mount(AdminLayout, globalConfig)
+        expect(wrapper.find('aside').classes()).toContain('-translate-x-full')
+    })
+
+    it('shows the sidebar after clicking the hamburger button', async () => {
+        const wrapper = mount(AdminLayout, globalConfig)
+
+        await wrapper.find('button[class*="lg:hidden"]').trigger('click')
+
+        expect(wrapper.find('aside').classes()).toContain('translate-x-0')
+        expect(wrapper.find('aside').classes()).not.toContain('-translate-x-full')
+    })
+
+    it('shows the backdrop when sidebar is open', async () => {
+        const wrapper = mount(AdminLayout, globalConfig)
+
+        expect(wrapper.find('[class*="bg-black"]').exists()).toBe(false)
+
+        await wrapper.find('button[class*="lg:hidden"]').trigger('click')
+
+        expect(wrapper.find('[class*="bg-black"]').exists()).toBe(true)
+    })
+
+    it('closes the sidebar when the backdrop is clicked', async () => {
+        const wrapper = mount(AdminLayout, globalConfig)
+
+        await wrapper.find('button[class*="lg:hidden"]').trigger('click')
+        expect(wrapper.find('aside').classes()).toContain('translate-x-0')
+
+        await wrapper.find('[class*="bg-black"]').trigger('click')
+
+        expect(wrapper.find('aside').classes()).toContain('-translate-x-full')
+    })
+
+    it('closes the sidebar when the page URL changes', async () => {
+        const wrapper = mount(AdminLayout, globalConfig)
+
+        await wrapper.find('button[class*="lg:hidden"]').trigger('click')
+        expect(wrapper.find('aside').classes()).toContain('translate-x-0')
+
+        currentUrl.value = '/admin/posts'
+        await flushPromises()
+
+        expect(wrapper.find('aside').classes()).toContain('-translate-x-full')
+    })
+})

--- a/laravel/resources/js/Layouts/AdminLayout.test.ts
+++ b/laravel/resources/js/Layouts/AdminLayout.test.ts
@@ -48,49 +48,58 @@ describe('AdminLayout', () => {
     })
 
     it('hides the sidebar by default', () => {
+        // Arrange
         const wrapper = mount(AdminLayout, globalConfig)
+
+        // Assert
         expect(wrapper.find('aside').classes()).toContain('-translate-x-full')
     })
 
     it('shows the sidebar after clicking the hamburger button', async () => {
+        // Arrange
         const wrapper = mount(AdminLayout, globalConfig)
 
+        // Act
         await wrapper.find('button[class*="lg:hidden"]').trigger('click')
 
+        // Assert
         expect(wrapper.find('aside').classes()).toContain('translate-x-0')
         expect(wrapper.find('aside').classes()).not.toContain('-translate-x-full')
     })
 
     it('shows the backdrop when sidebar is open', async () => {
+        // Arrange
         const wrapper = mount(AdminLayout, globalConfig)
 
-        expect(wrapper.find('[class*="bg-black"]').exists()).toBe(false)
-
+        // Act
         await wrapper.find('button[class*="lg:hidden"]').trigger('click')
 
+        // Assert
         expect(wrapper.find('[class*="bg-black"]').exists()).toBe(true)
     })
 
     it('closes the sidebar when the backdrop is clicked', async () => {
+        // Arrange
         const wrapper = mount(AdminLayout, globalConfig)
-
         await wrapper.find('button[class*="lg:hidden"]').trigger('click')
-        expect(wrapper.find('aside').classes()).toContain('translate-x-0')
 
+        // Act
         await wrapper.find('[class*="bg-black"]').trigger('click')
 
+        // Assert
         expect(wrapper.find('aside').classes()).toContain('-translate-x-full')
     })
 
     it('closes the sidebar when the page URL changes', async () => {
+        // Arrange
         const wrapper = mount(AdminLayout, globalConfig)
-
         await wrapper.find('button[class*="lg:hidden"]').trigger('click')
-        expect(wrapper.find('aside').classes()).toContain('translate-x-0')
 
+        // Act
         currentUrl.value = '/admin/posts'
         await flushPromises()
 
+        // Assert
         expect(wrapper.find('aside').classes()).toContain('-translate-x-full')
     })
 })

--- a/laravel/resources/js/Layouts/AdminLayout.vue
+++ b/laravel/resources/js/Layouts/AdminLayout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref, watch } from "vue";
 import { Link, usePage, useForm } from "@inertiajs/vue3";
 import { route } from "ziggy-js";
 import { useAuthStore } from "@/stores/useAuthStore";
@@ -11,6 +11,9 @@ const page = usePage<SharedProps>();
 const appName = computed(() => page.props.app.name);
 
 const logoutForm = useForm({});
+const sidebarOpen = ref(false)
+
+watch(() => page.url, () => { sidebarOpen.value = false })
 
 function logout() {
     logoutForm.post(route("admin.logout"));
@@ -19,8 +22,20 @@ function logout() {
 
 <template>
   <div class="flex h-screen bg-background">
+    <!-- Mobile sidebar backdrop -->
+    <div
+      v-if="sidebarOpen"
+      class="fixed inset-0 z-20 bg-black/50 lg:hidden"
+      @click="sidebarOpen = false"
+    />
+
     <!-- Sidebar -->
-    <aside class="flex w-64 flex-col border-r bg-card">
+    <aside
+      :class="[
+        'fixed inset-y-0 left-0 z-30 flex w-64 flex-col border-r bg-card transition-transform duration-200 lg:static lg:translate-x-0',
+        sidebarOpen ? 'translate-x-0' : '-translate-x-full',
+      ]"
+    >
       <!-- App name -->
       <div class="flex h-16 items-center border-b px-6">
         <span class="text-lg font-semibold">{{ appName }}</span>
@@ -61,11 +76,32 @@ function logout() {
     <div class="flex flex-1 flex-col overflow-hidden">
       <!-- Top bar -->
       <header
-        class="flex h-16 items-center justify-between border-b bg-card px-6"
+        class="flex h-16 items-center justify-between border-b bg-card px-4 lg:px-6"
       >
-        <h1 class="text-lg font-semibold">
-          <slot name="title" />
-        </h1>
+        <div class="flex items-center gap-3">
+          <!-- Hamburger (mobile only) -->
+          <button
+            class="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground lg:hidden"
+            @click="sidebarOpen = true"
+          >
+            <svg
+              class="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M4 6h16M4 12h16M4 18h16"
+              />
+            </svg>
+          </button>
+          <h1 class="text-lg font-semibold">
+            <slot name="title" />
+          </h1>
+        </div>
         <button
           class="text-sm text-muted-foreground hover:text-foreground"
           @click="logout"

--- a/laravel/resources/js/app.test.ts
+++ b/laravel/resources/js/app.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 
 describe('app bootstrap', () => {
     it('runs in a js module environment', () => {
+        // Arrange + Assert (no act needed for environment checks)
         expect(typeof window).toBe('object')
     })
 })

--- a/laravel/vite.config.ts
+++ b/laravel/vite.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
     test: {
         environment: 'jsdom',
         globals: true,
-        include: ['resources/js/**/*.{test,spec}.{ts,js}'],
+        include: ['resources/js/**/*.test.{ts,js}'],
         coverage: {
             provider: 'v8',
             reporter: ['clover', 'text'],

--- a/plan.md
+++ b/plan.md
@@ -52,7 +52,7 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 | [#84](https://github.com/Three-Hoops/Hoops-CMS/issues/84) | Add remember me to login form | `auth`, `enhancement` |
 | [#109](https://github.com/Three-Hoops/Hoops-CMS/issues/109) | Add branded transactional email templates | `auth`, `enhancement` |
 | [#89](https://github.com/Three-Hoops/Hoops-CMS/issues/89) | Implement Content Security Policy (CSP) for admin panel | `security` |
-| [#82](https://github.com/Three-Hoops/Hoops-CMS/issues/82) | Make admin layout mobile-responsive | `enhancement` |
+| ✅ | [#82](https://github.com/Three-Hoops/Hoops-CMS/issues/82) | Make admin layout mobile-responsive | `enhancement` |
 | [#14](https://github.com/Three-Hoops/Hoops-CMS/issues/14) | Configure rate limiting on the login endpoint | `security` |
 | [#16](https://github.com/Three-Hoops/Hoops-CMS/issues/16) | Add security headers middleware | `security` |
 | [#42](https://github.com/Three-Hoops/Hoops-CMS/issues/42) | Configure session security and timeout | `security` |


### PR DESCRIPTION
## Summary

- Sidebar hidden off-screen on mobile, slides in with CSS transition on hamburger tap
- Semi-transparent backdrop closes sidebar when tapped outside
- Hamburger button (`lg:hidden`) added to top bar on mobile
- Sidebar auto-closes on any navigation by watching `page.url` — no per-link handling needed as nav grows in future phases
- Desktop layout (`lg:`) is unchanged

## Test plan

- [ ] On mobile viewport: confirm sidebar is hidden by default
- [ ] Tap hamburger — confirm sidebar slides in and backdrop appears
- [ ] Tap backdrop — confirm sidebar closes
- [ ] Navigate to a page — confirm sidebar closes automatically
- [ ] On desktop: confirm sidebar is always visible, hamburger hidden

Closes #82 

🤖 Generated with [Claude Code](https://claude.com/claude-code)