### PR TITLE
Add is_active flag for account suspension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ Browser → Laravel `routes/web.php` → Controller calls `Inertia::render('Fold
 - **Path alias**: `@/` resolves to `resources/js/` (configured in both `tsconfig.json` and `vite.config.ts`).
 - **Testing**: Vitest + `@vue/test-utils` for unit/component tests (co-located as `*.test.ts`); Cypress for e2e (requires `php artisan serve` running). **Always write tests when implementing new functionality** — see Testing Rules below.
 - **Lazy loading**: `Model::preventLazyLoading()` is active in all non-production environments. If you see a `LazyLoadingViolationException`, fix it by eager-loading the relationship in the controller: `Post::with(['category', 'tags'])->paginate()`.
+- **Vite manifest in PHP tests**: The CI PHP test job has no built frontend assets. Any feature test that hits an Inertia route (i.e. renders a Vue page) must call `$this->withoutVite()` at the start of the test, otherwise CI will fail with `Vite manifest not found`.
 - **Vue SFC order**: always `<script setup lang="ts">` first, then `<template>`, then `<style>` (if needed). Never use Options API.
 
 ## Testing Rules

--- a/laravel/app/Enums/FlashType.php
+++ b/laravel/app/Enums/FlashType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum FlashType: string
+{
+    case Success = 'success';
+    case Error   = 'error';
+}

--- a/laravel/app/Http/Controllers/Admin/AuthController.php
+++ b/laravel/app/Http/Controllers/Admin/AuthController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Enums\FlashType;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\LoginRequest;
 use Illuminate\Http\RedirectResponse;
@@ -29,6 +30,6 @@ class AuthController extends Controller
         request()->session()->invalidate();
         request()->session()->regenerateToken();
 
-        return redirect()->route('admin.login')->with('success', 'You have been logged out.');
+        return redirect()->route('admin.login')->with(FlashType::Success->value, 'You have been logged out.');
     }
 }

--- a/laravel/app/Http/Middleware/EnsureUserIsActive.php
+++ b/laravel/app/Http/Middleware/EnsureUserIsActive.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserIsActive
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if ($user instanceof User && ! $user->is_active) {
+            Auth::logout();
+
+            return redirect()->route('admin.login')->with('flash', [
+                'type'    => 'error',
+                'message' => 'Your account has been deactivated. Please contact an administrator.',
+            ]);
+        }
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Http/Middleware/EnsureUserIsActive.php
+++ b/laravel/app/Http/Middleware/EnsureUserIsActive.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Enums\FlashType;
 use App\Models\User;
 use Closure;
 use Illuminate\Http\Request;
@@ -17,10 +18,7 @@ class EnsureUserIsActive
         if ($user instanceof User && ! $user->is_active) {
             Auth::logout();
 
-            return redirect()->route('admin.login')->with('flash', [
-                'type'    => 'error',
-                'message' => 'Your account has been deactivated. Please contact an administrator.',
-            ]);
+            return redirect()->route('admin.login')->with(FlashType::Error->value, 'Your account has been deactivated. Please contact an administrator.');
         }
 
         return $next($request);

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -14,8 +14,9 @@ use App\Enums\UserRole;
 /**
  * @property UserRole $role
  * @property \Illuminate\Support\Carbon|null $last_login_at
+ * @property bool $is_active
  */
-#[Fillable(['name', 'email', 'password', 'role', 'last_login_at'])]
+#[Fillable(['name', 'email', 'password', 'role', 'last_login_at', 'is_active'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {
@@ -34,6 +35,7 @@ class User extends Authenticatable
             'last_login_at'     => 'datetime',
             'password'          => 'hashed',
             'role'              => UserRole::class,
+            'is_active'         => 'boolean',
         ];
     }
 }

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\EnsureUserHasRole;
+use App\Http\Middleware\EnsureUserIsActive;
 use App\Http\Middleware\HandleInertiaRequests;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -19,6 +20,10 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->alias([
             'role' => EnsureUserHasRole::class,
+        ]);
+
+        $middleware->alias([
+            'active' => EnsureUserIsActive::class,
         ]);
 
         $middleware->redirectGuestsTo('/admin/login');

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -30,6 +30,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'is_active' => true,
         ];
     }
 

--- a/laravel/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/laravel/database/migrations/0001_01_01_000000_create_users_table.php
@@ -22,6 +22,7 @@ return new class extends Migration
             $table->timestamps();
             $table->enum('role', array_column(UserRole::cases(), 'value'))->default(UserRole::Editor->value);
             $table->timestamp('last_login_at')->nullable();
+            $table->boolean('is_active')->default(true)->index();
         });
 
         Schema::create('password_reset_tokens', function (Blueprint $table) {

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -22,8 +22,7 @@ class DatabaseSeeder extends Seeder
             [
                 'name'     => 'Admin',
                 'password' => Hash::make('password'),
-                'role'     => UserRole::SuperAdmin,
-                'remember' => false,
+                'role'      => UserRole::SuperAdmin,
                 'is_active' => true,
             ]
         );

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -24,6 +24,7 @@ class DatabaseSeeder extends Seeder
                 'password' => Hash::make('password'),
                 'role'     => UserRole::SuperAdmin,
                 'remember' => false,
+                'is_active' => true,
             ]
         );
     }

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -13,7 +13,7 @@ Route::middleware('guest')->group(function () {
     Route::post('/admin/login', [AuthController::class, 'login'])->name('admin.post.login');
 });
 
-Route::middleware('auth')->group(function () {
+Route::middleware(['auth', 'active'])->group(function () {
     Route::get('/admin', [DashboardController::class, 'index'])->name('admin.dashboard');
     Route::post('/admin/logout', [AuthController::class, 'logout'])->name('admin.logout');    
 });

--- a/laravel/tests/Feature/Admin/EnsureUserIsActiveTest.php
+++ b/laravel/tests/Feature/Admin/EnsureUserIsActiveTest.php
@@ -14,6 +14,7 @@ class EnsureUserIsActiveTest extends TestCase
     public function test_active_user_can_access_admin(): void
     {
         // Arrange
+        $this->withoutVite();
         $user = User::factory()->create(['is_active' => true]);
 
         // Act

--- a/laravel/tests/Feature/Admin/EnsureUserIsActiveTest.php
+++ b/laravel/tests/Feature/Admin/EnsureUserIsActiveTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\FlashType;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EnsureUserIsActiveTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_active_user_can_access_admin(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['is_active' => true]);
+
+        // Act
+        $response = $this->actingAs($user)->get('/admin');
+
+        // Assert
+        $response->assertOk();
+    }
+
+    public function test_inactive_user_is_redirected_to_login(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['is_active' => false]);
+
+        // Act
+        $response = $this->actingAs($user)->get('/admin');
+
+        // Assert
+        $response->assertRedirect(route('admin.login'));
+    }
+
+    public function test_inactive_user_is_logged_out(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['is_active' => false]);
+
+        // Act
+        $this->actingAs($user)->get('/admin');
+
+        // Assert
+        $this->assertGuest();
+    }
+
+    public function test_inactive_user_sees_error_flash_message(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['is_active' => false]);
+
+        // Act
+        $response = $this->actingAs($user)->get('/admin');
+
+        // Assert
+        $response->assertSessionHas(FlashType::Error->value);
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -47,7 +47,7 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 | [#71](https://github.com/Three-Hoops/Hoops-CMS/issues/71) | Add locale column to users table for editor language preference | `auth`, `enhancement` |
 | [#103](https://github.com/Three-Hoops/Hoops-CMS/issues/103) | Add timezone preference to users for correct scheduled publishing | `auth`, `enhancement` |
 | ✅ | [#77](https://github.com/Three-Hoops/Hoops-CMS/issues/77) | Track last_login_at on users | `auth`, `security` |
-| [#85](https://github.com/Three-Hoops/Hoops-CMS/issues/85) | Add is_active flag to users for account suspension | `auth`, `security` |
+| ✅ | [#86](https://github.com/Three-Hoops/Hoops-CMS/issues/86) | Add is_active flag to users for account suspension | `auth`, `security` |
 | [#106](https://github.com/Three-Hoops/Hoops-CMS/issues/106) | Define and enforce viewer role capabilities | `auth`, `security` |
 | ✅ | [#84](https://github.com/Three-Hoops/Hoops-CMS/issues/84) | Add remember me to login form | `auth`, `enhancement` |
 | [#109](https://github.com/Three-Hoops/Hoops-CMS/issues/109) | Add branded transactional email templates | `auth`, `enhancement` |
@@ -72,7 +72,7 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 | [#70](https://github.com/Three-Hoops/Hoops-CMS/issues/70) | Add multilingual content support with spatie/laravel-translatable | `content`, `enhancement` |
 | [#2](https://github.com/Three-Hoops/Hoops-CMS/issues/2) | Phase 2: Core Content (Pages, Posts, Categories, Tags) | `content`, `enhancement` |
 | [#76](https://github.com/Three-Hoops/Hoops-CMS/issues/76) | Add parent_id to pages table for hierarchical page structure | `content`, `enhancement` |
-| [#86](https://github.com/Three-Hoops/Hoops-CMS/issues/86) | Add duplicate action for posts and pages | `content`, `enhancement` |
+| [#85](https://github.com/Three-Hoops/Hoops-CMS/issues/85) | Add duplicate action for posts and pages | `content`, `enhancement` |
 | [#65](https://github.com/Three-Hoops/Hoops-CMS/issues/65) | Add per-post and per-page Open Graph / social meta fields | `content`, `enhancement` |
 | [#69](https://github.com/Three-Hoops/Hoops-CMS/issues/69) | Add featured/pinned flag to posts | `content`, `enhancement` |
 | [#17](https://github.com/Three-Hoops/Hoops-CMS/issues/17) | Add soft deletes to content models | `content` |


### PR DESCRIPTION
Closes #86

## Summary
- Added `is_active` boolean column to users table (default `true`)
- `EnsureUserIsActive` middleware blocks inactive users, logs them out, and redirects to login with an error flash message
- Registered middleware as `active` alias, applied to all authenticated admin routes
- Introduced `FlashType` enum (`Success`, `Error`) to centralise flash session key strings
- Fixed `UserFactory` to explicitly set `is_active: true` so tests aren't blocked by the new middleware
- Fixed seeder removing stale `remember` field

## Test plan
- [ ] Active user can access `/admin`
- [ ] Inactive user is redirected to login and logged out
- [ ] Inactive user sees error flash message
- [ ] All 12 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)