### PR TITLE
Configure rate limiting on login endpoint

### DIFF
--- a/laravel/app/Http/Requests/Admin/LoginRequest.php
+++ b/laravel/app/Http/Requests/Admin/LoginRequest.php
@@ -45,7 +45,7 @@ class LoginRequest extends FormRequest
 
     public function ensureIsNotRateLimited(): void
     {
-        if(! RateLimiter::tooManyAttempts($this->throttleKey(), 5)) {
+        if (! RateLimiter::tooManyAttempts($this->throttleKey(), 3)) {
             return;
         }
 
@@ -54,7 +54,7 @@ class LoginRequest extends FormRequest
         $seconds = RateLimiter::availableIn($this->throttleKey());
 
         throw ValidationException::withMessages([
-            'email' => trans('auth.throttle', ['seconds' => $seconds, 'minutes' => ceil($seconds / 60)]),
+            'throttle' => trans('auth.throttle', ['seconds' => $seconds, 'minutes' => ceil($seconds / 60)]),
         ]);
     }
 

--- a/laravel/resources/js/Pages/Admin/Auth/Login.test.ts
+++ b/laravel/resources/js/Pages/Admin/Auth/Login.test.ts
@@ -2,21 +2,16 @@ import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import Login from './Login.vue'
 
-const mockFormErrors: Record<string, string> = {}
+const mockErrors: Record<string, string> = {}
 const mockFlash = { success: null as string | null, error: null as string | null }
+const mockPost = vi.fn()
 const mockReset = vi.fn()
-
-const mockPost = vi.fn((_, options?: { onError?: (e: Record<string, string>) => void }) => {
-    if (options?.onError && mockFormErrors.throttle) {
-        options.onError(mockFormErrors)
-    }
-})
 
 vi.mock('@inertiajs/vue3', () => ({
     usePage: () => ({
         props: {
             flash: mockFlash,
-            errors: {},
+            errors: mockErrors,
         },
     }),
     useForm: () => ({
@@ -24,7 +19,7 @@ vi.mock('@inertiajs/vue3', () => ({
         password: '',
         remember: false,
         processing: false,
-        errors: mockFormErrors,
+        errors: {},
         post: mockPost,
         reset: mockReset,
     }),
@@ -50,20 +45,17 @@ const globalConfig = {
 
 describe('Login', () => {
     beforeEach(() => {
-        Object.keys(mockFormErrors).forEach(key => delete mockFormErrors[key])
+        Object.keys(mockErrors).forEach(key => delete mockErrors[key])
         mockFlash.success = null
         mockFlash.error = null
         mockPost.mockReset()
         mockReset.mockReset()
     })
 
-    it('shows throttle error banner when throttle error is present', async () => {
+    it('shows throttle error banner when throttle error is present', () => {
         // Arrange
-        mockFormErrors.throttle = 'Too many login attempts. Please try again in 60 seconds.'
+        mockErrors.throttle = 'Too many login attempts. Please try again in 60 seconds.'
         const wrapper = mount(Login, globalConfig)
-
-        // Act
-        await wrapper.find('form').trigger('submit')
 
         // Assert
         expect(wrapper.find('.bg-red-50').exists()).toBe(true)

--- a/laravel/resources/js/Pages/Admin/Auth/Login.test.ts
+++ b/laravel/resources/js/Pages/Admin/Auth/Login.test.ts
@@ -2,19 +2,22 @@ import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import Login from './Login.vue'
 
-const mockPageProps = {
-    flash: { success: null as string | null, error: null as string | null },
-    errors: {} as Record<string, string>,
-}
+const mockFormErrors: Record<string, string> = {}
+const mockFlash = { success: null as string | null, error: null as string | null }
 
 vi.mock('@inertiajs/vue3', () => ({
-    usePage: () => ({ props: mockPageProps }),
+    usePage: () => ({
+        props: {
+            flash: mockFlash,
+            errors: {},
+        },
+    }),
     useForm: () => ({
         email: '',
         password: '',
         remember: false,
         processing: false,
-        errors: {},
+        errors: mockFormErrors,
         post: vi.fn(),
         reset: vi.fn(),
     }),
@@ -40,13 +43,14 @@ const globalConfig = {
 
 describe('Login', () => {
     beforeEach(() => {
-        mockPageProps.flash = { success: null, error: null }
-        mockPageProps.errors = {}
+        Object.keys(mockFormErrors).forEach(key => delete mockFormErrors[key])
+        mockFlash.success = null
+        mockFlash.error = null
     })
 
     it('shows throttle error banner when throttle error is present', () => {
         // Arrange
-        mockPageProps.errors = { throttle: 'Too many login attempts. Please try again in 60 seconds.' }
+        mockFormErrors.throttle = 'Too many login attempts. Please try again in 60 seconds.'
         const wrapper = mount(Login, globalConfig)
 
         // Assert
@@ -64,7 +68,7 @@ describe('Login', () => {
 
     it('shows success flash message on logout', () => {
         // Arrange
-        mockPageProps.flash = { success: 'You have been logged out.', error: null }
+        mockFlash.success = 'You have been logged out.'
         const wrapper = mount(Login, globalConfig)
 
         // Assert

--- a/laravel/resources/js/Pages/Admin/Auth/Login.test.ts
+++ b/laravel/resources/js/Pages/Admin/Auth/Login.test.ts
@@ -4,8 +4,13 @@ import Login from './Login.vue'
 
 const mockFormErrors: Record<string, string> = {}
 const mockFlash = { success: null as string | null, error: null as string | null }
-const mockPost = vi.fn()
 const mockReset = vi.fn()
+
+const mockPost = vi.fn((_, options?: { onError?: (e: Record<string, string>) => void }) => {
+    if (options?.onError && mockFormErrors.throttle) {
+        options.onError(mockFormErrors)
+    }
+})
 
 vi.mock('@inertiajs/vue3', () => ({
     usePage: () => ({
@@ -52,10 +57,13 @@ describe('Login', () => {
         mockReset.mockReset()
     })
 
-    it('shows throttle error banner when throttle error is present', () => {
+    it('shows throttle error banner when throttle error is present', async () => {
         // Arrange
         mockFormErrors.throttle = 'Too many login attempts. Please try again in 60 seconds.'
         const wrapper = mount(Login, globalConfig)
+
+        // Act
+        await wrapper.find('form').trigger('submit')
 
         // Assert
         expect(wrapper.find('.bg-red-50').exists()).toBe(true)

--- a/laravel/resources/js/Pages/Admin/Auth/Login.test.ts
+++ b/laravel/resources/js/Pages/Admin/Auth/Login.test.ts
@@ -4,6 +4,8 @@ import Login from './Login.vue'
 
 const mockFormErrors: Record<string, string> = {}
 const mockFlash = { success: null as string | null, error: null as string | null }
+const mockPost = vi.fn()
+const mockReset = vi.fn()
 
 vi.mock('@inertiajs/vue3', () => ({
     usePage: () => ({
@@ -18,8 +20,8 @@ vi.mock('@inertiajs/vue3', () => ({
         remember: false,
         processing: false,
         errors: mockFormErrors,
-        post: vi.fn(),
-        reset: vi.fn(),
+        post: mockPost,
+        reset: mockReset,
     }),
 }))
 
@@ -46,6 +48,8 @@ describe('Login', () => {
         Object.keys(mockFormErrors).forEach(key => delete mockFormErrors[key])
         mockFlash.success = null
         mockFlash.error = null
+        mockPost.mockReset()
+        mockReset.mockReset()
     })
 
     it('shows throttle error banner when throttle error is present', () => {
@@ -74,5 +78,16 @@ describe('Login', () => {
         // Assert
         expect(wrapper.find('.bg-green-50').exists()).toBe(true)
         expect(wrapper.find('.bg-green-50').text()).toContain('You have been logged out.')
+    })
+
+    it('submits the form when the sign in button is clicked', async () => {
+        // Arrange
+        const wrapper = mount(Login, globalConfig)
+
+        // Act
+        await wrapper.find('form').trigger('submit')
+
+        // Assert
+        expect(mockPost).toHaveBeenCalledWith('/admin.post.login', expect.objectContaining({ onFinish: expect.any(Function) }))
     })
 })

--- a/laravel/resources/js/Pages/Admin/Auth/Login.test.ts
+++ b/laravel/resources/js/Pages/Admin/Auth/Login.test.ts
@@ -1,0 +1,74 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Login from './Login.vue'
+
+const mockPageProps = {
+    flash: { success: null as string | null, error: null as string | null },
+    errors: {} as Record<string, string>,
+}
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({ props: mockPageProps }),
+    useForm: () => ({
+        email: '',
+        password: '',
+        remember: false,
+        processing: false,
+        errors: {},
+        post: vi.fn(),
+        reset: vi.fn(),
+    }),
+}))
+
+vi.mock('ziggy-js', () => ({
+    route: (name: string) => `/${name}`,
+}))
+
+const globalConfig = {
+    global: {
+        stubs: {
+            Button: { template: '<button><slot /></button>' },
+            Card: { template: '<div><slot /></div>' },
+            CardContent: { template: '<div><slot /></div>' },
+            CardHeader: { template: '<div><slot /></div>' },
+            CardTitle: { template: '<div><slot /></div>' },
+            Input: { template: '<input />' },
+            Label: { template: '<label><slot /></label>' },
+        },
+    },
+}
+
+describe('Login', () => {
+    beforeEach(() => {
+        mockPageProps.flash = { success: null, error: null }
+        mockPageProps.errors = {}
+    })
+
+    it('shows throttle error banner when throttle error is present', () => {
+        // Arrange
+        mockPageProps.errors = { throttle: 'Too many login attempts. Please try again in 60 seconds.' }
+        const wrapper = mount(Login, globalConfig)
+
+        // Assert
+        expect(wrapper.find('.bg-red-50').exists()).toBe(true)
+        expect(wrapper.find('.bg-red-50').text()).toContain('Too many login attempts')
+    })
+
+    it('does not show throttle error banner when no throttle error', () => {
+        // Arrange
+        const wrapper = mount(Login, globalConfig)
+
+        // Assert
+        expect(wrapper.find('.bg-red-50').exists()).toBe(false)
+    })
+
+    it('shows success flash message on logout', () => {
+        // Arrange
+        mockPageProps.flash = { success: 'You have been logged out.', error: null }
+        const wrapper = mount(Login, globalConfig)
+
+        // Assert
+        expect(wrapper.find('.bg-green-50').exists()).toBe(true)
+        expect(wrapper.find('.bg-green-50').text()).toContain('You have been logged out.')
+    })
+})

--- a/laravel/resources/js/Pages/Admin/Auth/Login.vue
+++ b/laravel/resources/js/Pages/Admin/Auth/Login.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { usePage, useForm } from "@inertiajs/vue3";
-import { computed } from "vue";
+import { ref } from "vue";
 import { route } from "ziggy-js";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -16,10 +16,14 @@ const form = useForm({
     remember: false,
 });
 
-const throttleError = computed(() => (form.errors as Record<string, string | undefined>).throttle)
+const throttleError = ref<string | null>(null)
 
 function submit() {
+    throttleError.value = null
     form.post(route("admin.post.login"), {
+        onError: (errors) => {
+            throttleError.value = (errors as Record<string, string>).throttle ?? null
+        },
         onFinish: () => form.reset("password"),
     });
 }

--- a/laravel/resources/js/Pages/Admin/Auth/Login.vue
+++ b/laravel/resources/js/Pages/Admin/Auth/Login.vue
@@ -1,25 +1,25 @@
 <script setup lang="ts">
-import { usePage } from '@inertiajs/vue3'
-import { useForm } from '@inertiajs/vue3'
-import { route } from 'ziggy-js'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import type { SharedProps } from '@/types/models'
+import { usePage } from "@inertiajs/vue3";
+import { useForm } from "@inertiajs/vue3";
+import { route } from "ziggy-js";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { SharedProps } from "@/types/models";
 
-const page = usePage<SharedProps>()
+const page = usePage<SharedProps>();
 
 const form = useForm({
-    email: '',
-    password: '',
+    email: "",
+    password: "",
     remember: false,
-})
+});
 
 function submit() {
-    form.post(route('admin.post.login'), {
-        onFinish: () => form.reset('password'),
-    })
+    form.post(route("admin.post.login"), {
+        onFinish: () => form.reset("password"),
+    });
 }
 </script>
 
@@ -31,6 +31,12 @@ function submit() {
         class="rounded-md bg-green-50 px-4 py-3 text-sm font-medium text-green-800"
       >
         {{ page.props.flash.success }}
+      </div>
+      <div
+        v-if="form.errors.throttle"
+        class="rounded-md bg-red-50 px-4 py-3 text-sm font-medium text-red-800"
+      >
+        {{ form.errors.throttle }}
       </div>
       <Card class="w-full">
         <CardHeader>
@@ -91,7 +97,7 @@ function submit() {
               class="w-full"
               :disabled="form.processing"
             >
-              {{ form.processing ? 'Signing in…' : 'Sign in' }}
+              {{ form.processing ? "Signing in…" : "Sign in" }}
             </Button>
           </form>
         </CardContent>

--- a/laravel/resources/js/Pages/Admin/Auth/Login.vue
+++ b/laravel/resources/js/Pages/Admin/Auth/Login.vue
@@ -31,7 +31,6 @@ function submit() {
       >
         {{ page.props.flash.success }}
       </div>
-      <pre class="text-xs">DEBUG errors: {{ JSON.stringify(page.props.errors) }}</pre>
       <div
         v-if="page.props.errors.throttle"
         class="rounded-md bg-red-50 px-4 py-3 text-sm font-medium text-red-800"

--- a/laravel/resources/js/Pages/Admin/Auth/Login.vue
+++ b/laravel/resources/js/Pages/Admin/Auth/Login.vue
@@ -31,6 +31,7 @@ function submit() {
       >
         {{ page.props.flash.success }}
       </div>
+      <pre class="text-xs">DEBUG errors: {{ JSON.stringify(page.props.errors) }}</pre>
       <div
         v-if="page.props.errors.throttle"
         class="rounded-md bg-red-50 px-4 py-3 text-sm font-medium text-red-800"

--- a/laravel/resources/js/Pages/Admin/Auth/Login.vue
+++ b/laravel/resources/js/Pages/Admin/Auth/Login.vue
@@ -33,10 +33,10 @@ function submit() {
         {{ page.props.flash.success }}
       </div>
       <div
-        v-if="form.errors.throttle"
+        v-if="page.props.errors.throttle"
         class="rounded-md bg-red-50 px-4 py-3 text-sm font-medium text-red-800"
       >
-        {{ form.errors.throttle }}
+        {{ page.props.errors.throttle }}
       </div>
       <Card class="w-full">
         <CardHeader>

--- a/laravel/resources/js/Pages/Admin/Auth/Login.vue
+++ b/laravel/resources/js/Pages/Admin/Auth/Login.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { usePage } from "@inertiajs/vue3";
-import { useForm } from "@inertiajs/vue3";
+import { usePage, useForm } from "@inertiajs/vue3";
+import { computed } from "vue";
 import { route } from "ziggy-js";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -15,6 +15,8 @@ const form = useForm({
     password: "",
     remember: false,
 });
+
+const throttleError = computed(() => (form.errors as Record<string, string | undefined>).throttle)
 
 function submit() {
     form.post(route("admin.post.login"), {
@@ -33,10 +35,10 @@ function submit() {
         {{ page.props.flash.success }}
       </div>
       <div
-        v-if="page.props.errors.throttle"
+        v-if="throttleError"
         class="rounded-md bg-red-50 px-4 py-3 text-sm font-medium text-red-800"
       >
-        {{ page.props.errors.throttle }}
+        {{ throttleError }}
       </div>
       <Card class="w-full">
         <CardHeader>

--- a/laravel/resources/js/Pages/Admin/Auth/Login.vue
+++ b/laravel/resources/js/Pages/Admin/Auth/Login.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { usePage, useForm } from "@inertiajs/vue3";
-import { ref } from "vue";
 import { route } from "ziggy-js";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -16,14 +15,8 @@ const form = useForm({
     remember: false,
 });
 
-const throttleError = ref<string | null>(null)
-
 function submit() {
-    throttleError.value = null
     form.post(route("admin.post.login"), {
-        onError: (errors) => {
-            throttleError.value = (errors as Record<string, string>).throttle ?? null
-        },
         onFinish: () => form.reset("password"),
     });
 }
@@ -39,10 +32,10 @@ function submit() {
         {{ page.props.flash.success }}
       </div>
       <div
-        v-if="throttleError"
+        v-if="page.props.errors.throttle"
         class="rounded-md bg-red-50 px-4 py-3 text-sm font-medium text-red-800"
       >
-        {{ throttleError }}
+        {{ page.props.errors.throttle }}
       </div>
       <Card class="w-full">
         <CardHeader>

--- a/laravel/resources/js/types/models.ts
+++ b/laravel/resources/js/types/models.ts
@@ -19,6 +19,7 @@ export interface SharedProps {
     }
     auth: AuthUser | null
     flash: FlashMessages
+    errors: Record<string, string>
     ziggy: {
         location: string
         [key: string]: unknown

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -10,7 +10,7 @@ Route::get('/', function () {
 
 Route::middleware('guest')->group(function () {
     Route::get('/admin/login', [AuthController::class, 'showLogin'])->name('admin.login');
-    Route::post('/admin/login', [AuthController::class, 'login'])->name('admin.post.login');
+    Route::post('/admin/login', [AuthController::class, 'login'])->name('admin.post.login')->middleware('throttle:3,1');
 });
 
 Route::middleware(['auth', 'active'])->group(function () {

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -10,7 +10,7 @@ Route::get('/', function () {
 
 Route::middleware('guest')->group(function () {
     Route::get('/admin/login', [AuthController::class, 'showLogin'])->name('admin.login');
-    Route::post('/admin/login', [AuthController::class, 'login'])->name('admin.post.login')->middleware('throttle:3,1');
+    Route::post('/admin/login', [AuthController::class, 'login'])->name('admin.post.login');
 });
 
 Route::middleware(['auth', 'active'])->group(function () {

--- a/laravel/tests/Feature/Admin/RateLimitingTest.php
+++ b/laravel/tests/Feature/Admin/RateLimitingTest.php
@@ -20,6 +20,7 @@ class RateLimitingTest extends TestCase
     public function test_login_succeeds_within_rate_limit(): void
     {
         // Arrange
+        $this->withoutVite();
         $user = User::factory()->create();
 
         // Act
@@ -79,7 +80,10 @@ class RateLimitingTest extends TestCase
 
     public function test_get_login_page_is_not_rate_limited(): void
     {
-        // Arrange + Act
+        // Arrange
+        $this->withoutVite();
+
+        // Act
         for ($i = 0; $i < 10; $i++) {
             $response = $this->get('/admin/login');
         }

--- a/laravel/tests/Feature/Admin/RateLimitingTest.php
+++ b/laravel/tests/Feature/Admin/RateLimitingTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\RateLimiter;
+use Tests\TestCase;
+
+class RateLimitingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        RateLimiter::clear('login');
+    }
+
+    public function test_login_succeeds_within_rate_limit(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+
+        // Act
+        $response = $this->post('/admin/login', [
+            'email'    => $user->email,
+            'password' => 'password',
+        ]);
+
+        // Assert
+        $response->assertRedirect(route('admin.dashboard'));
+    }
+
+    public function test_login_is_blocked_after_too_many_attempts(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+
+        // Act — exhaust the 3 allowed attempts
+        for ($i = 0; $i < 3; $i++) {
+            $this->post('/admin/login', [
+                'email'    => $user->email,
+                'password' => 'wrong-password',
+            ]);
+        }
+
+        $response = $this->post('/admin/login', [
+            'email'    => $user->email,
+            'password' => 'wrong-password',
+        ]);
+
+        // Assert
+        $response->assertSessionHasErrors('throttle');
+    }
+
+    public function test_correct_credentials_are_blocked_once_rate_limited(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+
+        // Act — exhaust the 3 allowed attempts with wrong password
+        for ($i = 0; $i < 3; $i++) {
+            $this->post('/admin/login', [
+                'email'    => $user->email,
+                'password' => 'wrong-password',
+            ]);
+        }
+
+        // Attempt with correct credentials after lockout
+        $response = $this->post('/admin/login', [
+            'email'    => $user->email,
+            'password' => 'password',
+        ]);
+
+        // Assert
+        $response->assertSessionHasErrors('throttle');
+    }
+
+    public function test_get_login_page_is_not_rate_limited(): void
+    {
+        // Arrange + Act
+        for ($i = 0; $i < 10; $i++) {
+            $response = $this->get('/admin/login');
+        }
+
+        // Assert
+        $response->assertOk();
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -53,7 +53,7 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 | [#109](https://github.com/Three-Hoops/Hoops-CMS/issues/109) | Add branded transactional email templates | `auth`, `enhancement` |
 | [#89](https://github.com/Three-Hoops/Hoops-CMS/issues/89) | Implement Content Security Policy (CSP) for admin panel | `security` |
 | ✅ | [#82](https://github.com/Three-Hoops/Hoops-CMS/issues/82) | Make admin layout mobile-responsive | `enhancement` |
-| [#14](https://github.com/Three-Hoops/Hoops-CMS/issues/14) | Configure rate limiting on the login endpoint | `security` |
+| ✅ | [#14](https://github.com/Three-Hoops/Hoops-CMS/issues/14) | Configure rate limiting on the login endpoint | `security` |
 | [#16](https://github.com/Three-Hoops/Hoops-CMS/issues/16) | Add security headers middleware | `security` |
 | [#42](https://github.com/Three-Hoops/Hoops-CMS/issues/42) | Configure session security and timeout | `security` |
 | [#46](https://github.com/Three-Hoops/Hoops-CMS/issues/46) | Add noindex meta tag to all admin pages | `security` |


### PR DESCRIPTION
Closes #14

## Summary
- Rate limiting is handled in `LoginRequest::ensureIsNotRateLimited()` using Laravel's `RateLimiter` — 3 attempts per email+IP combination per minute
- Lockout throws a `ValidationException` with a `throttle` key so Inertia can surface it in `page.props.errors`
- `Login.vue` displays the throttle error in a red banner above the form
- Removed redundant `throttle:3,1` route middleware (the `LoginRequest` approach is more precise — it keys on email+IP rather than IP alone)

## Test plan
- [x] Successful login works within the limit
- [ ] After 3 failed attempts the next attempt (even with correct credentials) is blocked with a `throttle` session error
- [ ] GET login page is never rate limited
- [x] All 16 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)