### PR TITLE
Add noindex meta tag to all admin pages

### DIFF
--- a/laravel/resources/js/Layouts/AdminLayout.test.ts
+++ b/laravel/resources/js/Layouts/AdminLayout.test.ts
@@ -16,6 +16,7 @@ vi.mock('@inertiajs/vue3', () => ({
         },
     }),
     useForm: () => ({ post: vi.fn(), processing: false }),
+    Head: { template: '<head><slot /></head>' },
     Link: { template: '<a><slot /></a>' },
 }))
 

--- a/laravel/resources/js/Layouts/AdminLayout.vue
+++ b/laravel/resources/js/Layouts/AdminLayout.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import { Link, usePage, useForm } from "@inertiajs/vue3";
+import { Head, Link, usePage, useForm } from "@inertiajs/vue3";
 import { route } from "ziggy-js";
 import { useAuthStore } from "@/stores/useAuthStore";
 import FlashBanner from "@/components/Admin/FlashBanner.vue";
@@ -21,6 +21,12 @@ function logout() {
 </script>
 
 <template>
+  <Head>
+    <meta
+      name="robots"
+      content="noindex, nofollow"
+    >
+  </Head>
   <div class="flex h-screen bg-background">
     <!-- Mobile sidebar backdrop -->
     <div

--- a/plan.md
+++ b/plan.md
@@ -56,7 +56,7 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 | ✅ | [#14](https://github.com/Three-Hoops/Hoops-CMS/issues/14) | Configure rate limiting on the login endpoint | `security` |
 | [#16](https://github.com/Three-Hoops/Hoops-CMS/issues/16) | Add security headers middleware | `security` |
 | [#42](https://github.com/Three-Hoops/Hoops-CMS/issues/42) | Configure session security and timeout | `security` |
-| [#46](https://github.com/Three-Hoops/Hoops-CMS/issues/46) | Add noindex meta tag to all admin pages | `security` |
+| ✅ | [#46](https://github.com/Three-Hoops/Hoops-CMS/issues/46) | Add noindex meta tag to all admin pages | `security` |
 | [#49](https://github.com/Three-Hoops/Hoops-CMS/issues/49) | Enforce password complexity policy for admin accounts | `security`, `auth` |
 | [#37](https://github.com/Three-Hoops/Hoops-CMS/issues/37) | Add password reset (forgot password) flow | `auth`, `enhancement` |
 | [#41](https://github.com/Three-Hoops/Hoops-CMS/issues/41) | Add custom Inertia error pages (404, 419, 500) | `enhancement` |


### PR DESCRIPTION
Closes #46

## Summary
- Adds `<meta name="robots" content="noindex, nofollow">` to `AdminLayout.vue` via Inertia's `<Head>` component
- Covers every admin page automatically; leaves the public site untouched

## Test plan
- [x] Visit any admin page and confirm `<meta name="robots" content="noindex, nofollow">` is present in the page source
- [x] Confirm the public home page does NOT have this meta tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)