### PR TITLE
Add locale column to users table

### DIFF
--- a/laravel/app/Http/Middleware/HandleInertiaRequests.php
+++ b/laravel/app/Http/Middleware/HandleInertiaRequests.php
@@ -48,6 +48,7 @@ class HandleInertiaRequests extends Middleware
                 'email'         => $request->user()->email,
                 'role'          => $request->user()->role,
                 'last_login_at' => $request->user()->last_login_at?->toISOString(),
+                'locale'        => $request->user()->locale,
             ] : null,
             'flash' => fn () => [
                 'success' => $request->session()->get('success'),

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -15,8 +15,9 @@ use App\Enums\UserRole;
  * @property UserRole $role
  * @property \Illuminate\Support\Carbon|null $last_login_at
  * @property bool $is_active
+ * @property string $locale
  */
-#[Fillable(['name', 'email', 'password', 'role', 'last_login_at', 'is_active'])]
+#[Fillable(['name', 'email', 'password', 'role', 'last_login_at', 'is_active', 'locale'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -31,6 +31,7 @@ class UserFactory extends Factory
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
             'is_active' => true,
+            'locale'=>'en',
         ];
     }
 

--- a/laravel/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/laravel/database/migrations/0001_01_01_000000_create_users_table.php
@@ -23,6 +23,7 @@ return new class extends Migration
             $table->enum('role', array_column(UserRole::cases(), 'value'))->default(UserRole::Editor->value);
             $table->timestamp('last_login_at')->nullable();
             $table->boolean('is_active')->default(true)->index();
+            $table->string('locale', 5)->default('en');
         });
 
         Schema::create('password_reset_tokens', function (Blueprint $table) {

--- a/laravel/resources/js/types/models.ts
+++ b/laravel/resources/js/types/models.ts
@@ -5,6 +5,7 @@ export interface AuthUser {
     name: string
     email: string
     role: UserRole
+    locale: string
     last_login_at: string | null
 }
 

--- a/laravel/tests/Feature/Admin/LocaleColumnTest.php
+++ b/laravel/tests/Feature/Admin/LocaleColumnTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LocaleColumnTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_locale_defaults_to_en(): void
+    {
+        // Arrange / Act
+        $user = User::factory()->create();
+
+        // Assert
+        $this->assertSame('en', $user->locale);
+    }
+
+    public function test_locale_is_shared_in_inertia_auth_prop(): void
+    {
+        // Arrange
+        $this->withoutVite();
+        $user = User::factory()->create(['locale' => 'fr']);
+
+        // Act
+        $response = $this->actingAs($user)->get('/admin');
+
+        // Assert
+        $response->assertInertia(fn ($page) => $page->where('auth.locale', 'fr'));
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -44,7 +44,7 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 | Status | # | Issue | Labels |
 |--------|---|-------|--------|
 | ✅ | [#1](https://github.com/Three-Hoops/Hoops-CMS/issues/1) | Phase 1: Auth + Admin Shell | `auth`, `enhancement` |
-| [#71](https://github.com/Three-Hoops/Hoops-CMS/issues/71) | Add locale column to users table for editor language preference | `auth`, `enhancement` |
+| ✅ | [#71](https://github.com/Three-Hoops/Hoops-CMS/issues/71) | Add locale column to users table for editor language preference | `auth`, `enhancement` |
 | [#103](https://github.com/Three-Hoops/Hoops-CMS/issues/103) | Add timezone preference to users for correct scheduled publishing | `auth`, `enhancement` |
 | ✅ | [#77](https://github.com/Three-Hoops/Hoops-CMS/issues/77) | Track last_login_at on users | `auth`, `security` |
 | ✅ | [#86](https://github.com/Three-Hoops/Hoops-CMS/issues/86) | Add is_active flag to users for account suspension | `auth`, `security` |


### PR DESCRIPTION
Closes #71

## Summary
- Adds `locale` string column (max 5 chars, default `'en'`) to the `users` table
- Adds `locale` to `User` fillable, factory default, and `@property` docblock
- Shares `locale` via the `auth` Inertia prop in `HandleInertiaRequests`
- Adds `locale: string` to the `AuthUser` TypeScript interface

## Test plan
- [x] `locale defaults to en` — factory-created user has `locale = 'en'`
- [x] `locale is shared in inertia auth prop` — authenticated GET to `/admin` includes `auth.locale`

🤖 Generated with [Claude Code](https://claude.com/claude-code)