### PR TITLE
Enforce password complexity policy for admin accounts

### DIFF
--- a/laravel/app/Http/Requests/Admin/LoginRequest.php
+++ b/laravel/app/Http/Requests/Admin/LoginRequest.php
@@ -21,7 +21,7 @@ class LoginRequest extends FormRequest
     {
         return [
             'email' => ['required', 'string', 'email'],
-            'password' => ['required', 'string'],
+            'password' => ['required', 'string', 'min:8'],
             'remember' => ['boolean'],
         ];
     }

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,7 +2,8 @@
 
 namespace App\Providers;
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model;                                                                                                                                                                                                                             
+use Illuminate\Validation\Rules\Password;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -21,5 +22,10 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Model::preventLazyLoading(! app()->isProduction());
+        Password::defaults(function () {
+            return app()->isProduction()
+                ? Password::min(12)->mixedCase()->numbers()->symbols()->uncompromised()
+                : Password::min(8);
+        });
     }
 }

--- a/laravel/tests/Feature/PasswordComplexityTest.php
+++ b/laravel/tests/Feature/PasswordComplexityTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\Rules\Password;
+use Tests\TestCase;
+
+class PasswordComplexityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_password_defaults_reject_password_shorter_than_8_characters(): void
+    {
+        // Arrange
+        $rule = Password::defaults();
+
+        // Act
+        $validator = validator(['password' => 'short'], ['password' => ['required', $rule]]);
+
+        // Assert
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('password', $validator->errors()->toArray());
+    }
+
+    public function test_password_defaults_accept_password_of_8_or_more_characters_in_non_production(): void
+    {
+        // Arrange
+        $rule = Password::defaults();
+
+        // Act
+        $validator = validator(['password' => 'longenough'], ['password' => ['required', $rule]]);
+
+        // Assert
+        $this->assertFalse($validator->fails());
+    }
+
+    public function test_login_does_not_enforce_complexity_rules(): void
+    {
+        // Arrange
+        $user = \App\Models\User::factory()->create();
+
+        // Act
+        $this->post('/admin/login', [
+            'email' => $user->email,
+            'password' => 'password',
+        ]);
+
+        // Assert — login succeeds with a simple password (complexity only enforced on creation)
+        $this->assertNotNull($user->fresh()->last_login_at);
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -57,7 +57,7 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 | ✅ | [#16](https://github.com/Three-Hoops/Hoops-CMS/issues/16) | Add security headers middleware | `security` |
 | ✅ | [#42](https://github.com/Three-Hoops/Hoops-CMS/issues/42) | Configure session security and timeout | `security` |
 | ✅ | [#46](https://github.com/Three-Hoops/Hoops-CMS/issues/46) | Add noindex meta tag to all admin pages | `security` |
-| [#49](https://github.com/Three-Hoops/Hoops-CMS/issues/49) | Enforce password complexity policy for admin accounts | `security`, `auth` |
+| ✅ | [#49](https://github.com/Three-Hoops/Hoops-CMS/issues/49) | Enforce password complexity policy for admin accounts | `security`, `auth` |
 | [#37](https://github.com/Three-Hoops/Hoops-CMS/issues/37) | Add password reset (forgot password) flow | `auth`, `enhancement` |
 | [#41](https://github.com/Three-Hoops/Hoops-CMS/issues/41) | Add custom Inertia error pages (404, 419, 500) | `enhancement` |
 | [#60](https://github.com/Three-Hoops/Hoops-CMS/issues/60) | Admin dark/light mode toggle (per-user preference) | `theming`, `enhancement` |


### PR DESCRIPTION
Closes #49

## Summary
- Registers `Password::defaults()` in `AppServiceProvider::boot()` — production enforces 12+ chars, mixed case, numbers, symbols, and HaveIBeenPwned check; non-production relaxes to min 8 to avoid dev friction
- `LoginRequest` keeps simple `min:8` only — complexity is enforced on account creation, not login
- Fixed a bug introduced during step 2: `LoginRequest` had incorrectly gained `confirmed` + `Password::default()`, which broke all login attempts (login forms have no confirmation field)

## Test plan
- [x] Passwords shorter than 8 chars are rejected by `Password::defaults()` in non-production
- [x] Passwords of 8+ chars are accepted in non-production
- [x] Login succeeds with a simple password — complexity not enforced on login
- [x] All 27 existing tests pass

## Notes
- `StoreUserRequest` and `UpdateUserRequest` (where `Password::defaults()` will be applied on creation) don't exist yet — they'll be added in Phase 4 (#4)
- Password strength indicator UI tracked in #4 (comment added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)