### PR TITLE
feat(#103): per-user timezone preference

### DIFF
--- a/laravel/app/Http/Controllers/Admin/UserPreferenceController.php
+++ b/laravel/app/Http/Controllers/Admin/UserPreferenceController.php
@@ -19,4 +19,15 @@ class UserPreferenceController extends Controller
 
         return back();
     }
+
+    public function updateTimeZone(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([                                                                                                                                                                                                                                        
+            'timezone' => ['required', 'string', 'timezone:all'],                                                                                                                                                                                                                
+        ]);
+
+        $request->user()->update(['timezone' => $validated['timezone']]);                                                                                                                                                                                                        
+
+        return back(); 
+    }
 }

--- a/laravel/app/Http/Middleware/HandleInertiaRequests.php
+++ b/laravel/app/Http/Middleware/HandleInertiaRequests.php
@@ -50,6 +50,7 @@ class HandleInertiaRequests extends Middleware
                 'last_login_at' => $request->user()->last_login_at?->toISOString(),
                 'locale'        => $request->user()->locale,
                 'theme_mode'    => $request->user()->theme_mode,
+                'timezone'      => $request->user()->timezone,
             ] : null,
             'flash' => fn () => [
                 'success' => $request->session()->get('success'),

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -18,7 +18,7 @@ use App\Enums\ThemeMode;
  * @property bool $is_active
  * @property string $locale
  */
-#[Fillable(['name', 'email', 'password', 'role', 'last_login_at', 'is_active', 'locale', 'theme_mode'])]
+#[Fillable(['name', 'email', 'password', 'role', 'last_login_at', 'is_active', 'locale', 'theme_mode', 'timezone'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -31,7 +31,8 @@ class UserFactory extends Factory
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
             'is_active' => true,
-            'locale'=>'en',
+            'locale'   => 'en',
+            'timezone' => 'UTC',
         ];
     }
 

--- a/laravel/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/laravel/database/migrations/0001_01_01_000000_create_users_table.php
@@ -26,6 +26,7 @@ return new class extends Migration
             $table->boolean('is_active')->default(true)->index();
             $table->string('locale', 5)->default('en');
             $table->enum('theme_mode', array_column(ThemeMode::cases(), 'value'))->default(ThemeMode::System->value);
+            $table->string('timezone', 64)->default('UTC');
         });
 
         Schema::create('password_reset_tokens', function (Blueprint $table) {

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -26,6 +26,7 @@ class DatabaseSeeder extends Seeder
                 'role'      => UserRole::SuperAdmin,
                 'is_active' => true,
                 'theme_mode'=> ThemeMode::System,
+                'timezone'=>'UTC',
             ]
         );
     }

--- a/laravel/resources/js/types/models.ts
+++ b/laravel/resources/js/types/models.ts
@@ -1,31 +1,32 @@
-export type UserRole = 'super_admin' | 'editor' | 'viewer'
-export type ThemeMode = 'light' | 'dark' | 'system'
+export type UserRole = "super_admin" | "editor" | "viewer";
+export type ThemeMode = "light" | "dark" | "system";
 
 export interface AuthUser {
-    id: number
-    name: string
-    email: string
-    role: UserRole
-    locale: string
-    last_login_at: string | null
-    theme_mode: ThemeMode
+    id: number;
+    name: string;
+    email: string;
+    role: UserRole;
+    locale: string;
+    last_login_at: string | null;
+    theme_mode: ThemeMode;
+    timezone: string;
 }
 
 export interface FlashMessages {
-    success: string | null
-    error: string | null
+    success: string | null;
+    error: string | null;
 }
 
 export interface SharedProps {
     app: {
-        name: string
-    }
-    auth: AuthUser | null
-    flash: FlashMessages
-    errors: Record<string, string>
+        name: string;
+    };
+    auth: AuthUser | null;
+    flash: FlashMessages;
+    errors: Record<string, string>;
     ziggy: {
-        location: string
-        [key: string]: unknown
-    }
-    [key: string]: unknown
+        location: string;
+        [key: string]: unknown;
+    };
+    [key: string]: unknown;
 }

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -27,4 +27,5 @@ Route::middleware(['auth', 'active', 'session.timeout'])->group(function () {
     Route::get('/admin', [DashboardController::class, 'index'])->name('admin.dashboard');
     Route::post('/admin/logout', [AuthController::class, 'logout'])->name('admin.logout');
     Route::put('/admin/preferences/theme', [UserPreferenceController::class, 'update'])->name('admin.preferences.theme');
+    Route::put('/admin/preferences/timezone', [UserPreferenceController::class, 'updateTimeZone'])->name('admin.preferences.timezone');
 });

--- a/laravel/tests/Feature/Admin/UserPreferenceTest.php
+++ b/laravel/tests/Feature/Admin/UserPreferenceTest.php
@@ -73,4 +73,60 @@ class UserPreferenceTest extends TestCase
             ]);
         }
     }
+
+    public function test_authenticated_user_can_update_timezone(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['timezone' => 'UTC']);
+
+        // Act
+        $response = $this->actingAs($user)->put('/admin/preferences/timezone', [
+            'timezone' => 'Europe/Brussels',
+        ]);
+
+        // Assert
+        $response->assertRedirect();
+        $this->assertDatabaseHas('users', [
+            'id'       => $user->id,
+            'timezone' => 'Europe/Brussels',
+        ]);
+    }
+
+    public function test_timezone_update_rejects_invalid_value(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+
+        // Act
+        $response = $this->actingAs($user)->put('/admin/preferences/timezone', [
+            'timezone' => 'Not/ATimezone',
+        ]);
+
+        // Assert
+        $response->assertSessionHasErrors('timezone');
+    }
+
+    public function test_guest_cannot_update_timezone(): void
+    {
+        // Act
+        $response = $this->put('/admin/preferences/timezone', [
+            'timezone' => 'Europe/Brussels',
+        ]);
+
+        // Assert
+        $response->assertRedirect(route('admin.login'));
+    }
+
+    public function test_timezone_is_shared_in_inertia_auth_prop(): void
+    {
+        // Arrange
+        $this->withoutVite();
+        $user = User::factory()->create(['timezone' => 'America/New_York']);
+
+        // Act
+        $response = $this->actingAs($user)->get('/admin');
+
+        // Assert
+        $response->assertInertia(fn ($page) => $page->where('auth.timezone', 'America/New_York'));
+    }
 }

--- a/plan.md
+++ b/plan.md
@@ -45,7 +45,7 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 |--------|---|-------|--------|
 | ✅ | [#1](https://github.com/Three-Hoops/Hoops-CMS/issues/1) | Phase 1: Auth + Admin Shell | `auth`, `enhancement` |
 | ✅ | [#71](https://github.com/Three-Hoops/Hoops-CMS/issues/71) | Add locale column to users table for editor language preference | `auth`, `enhancement` |
-| [#103](https://github.com/Three-Hoops/Hoops-CMS/issues/103) | Add timezone preference to users for correct scheduled publishing | `auth`, `enhancement` |
+| ✅ | [#103](https://github.com/Three-Hoops/Hoops-CMS/issues/103) | Add timezone preference to users for correct scheduled publishing | `auth`, `enhancement` |
 | ✅ | [#77](https://github.com/Three-Hoops/Hoops-CMS/issues/77) | Track last_login_at on users | `auth`, `security` |
 | ✅ | [#86](https://github.com/Three-Hoops/Hoops-CMS/issues/86) | Add is_active flag to users for account suspension | `auth`, `security` |
 | [#106](https://github.com/Three-Hoops/Hoops-CMS/issues/106) | Define and enforce viewer role capabilities | `auth`, `security` |


### PR DESCRIPTION
Closes #103

## Summary
- Adds a `timezone` column to the `users` table (string, default `UTC`)
- New `PUT /admin/preferences/timezone` endpoint validated against PHP's full IANA timezone list (`timezone:all`)
- Timezone exposed on the Inertia `auth` shared prop so Vue components can access it
- `timezone` added to `AuthUser` TypeScript type, `UserFactory`, and the database seeder

## Test plan
- [ ] Run `php artisan migrate:fresh --seed` and verify the admin user has `timezone = UTC`
- [ ] `PUT /admin/preferences/timezone` with a valid timezone (e.g. `Europe/Brussels`) persists correctly
- [ ] Invalid timezone values are rejected with a validation error
- [ ] Unauthenticated requests redirect to login
- [ ] `auth.timezone` is present in Inertia shared props on authenticated pages
- [ ] Run `php artisan test tests/Feature/Admin/UserPreferenceTest.php` — all 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)