### PR TITLE
feat(#156): add content migrations (categories, tags, pages, posts, post_tag)

### DIFF
--- a/laravel/database/migrations/2026_04_20_092426_create_categories_table.php
+++ b/laravel/database/migrations/2026_04_20_092426_create_categories_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/laravel/database/migrations/2026_04_20_092426_create_categories_table.php
+++ b/laravel/database/migrations/2026_04_20_092426_create_categories_table.php
@@ -14,6 +14,12 @@ return new class extends Migration
         Schema::create('categories', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->unsignedBigInteger('parent_id')->nullable();
+            $table->foreign('parent_id')->references('id')->on('categories')->onDelete('set null');
+            $table->index('parent_id');
         });
     }
 

--- a/laravel/database/migrations/2026_04_20_092426_create_pages_table.php
+++ b/laravel/database/migrations/2026_04_20_092426_create_pages_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('pages', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('pages');
+    }
+};

--- a/laravel/database/migrations/2026_04_20_092426_create_pages_table.php
+++ b/laravel/database/migrations/2026_04_20_092426_create_pages_table.php
@@ -14,6 +14,20 @@ return new class extends Migration
         Schema::create('pages', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->longText('content');
+            $table->json('content_json');
+            $table->text('excerpt')->nullable();
+            $table->enum('status', ['draft', 'published'])->default('draft');
+            $table->string('meta_title')->nullable();
+            $table->string('meta_description')->nullable();
+            $table->string('meta_keywords')->nullable();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamp('published_at')->nullable();
+            $table->softDeletes();
+            $table->index('status');
+            $table->index('published_at');
         });
     }
 

--- a/laravel/database/migrations/2026_04_20_092426_create_posts_table.php
+++ b/laravel/database/migrations/2026_04_20_092426_create_posts_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+};

--- a/laravel/database/migrations/2026_04_20_092426_create_posts_table.php
+++ b/laravel/database/migrations/2026_04_20_092426_create_posts_table.php
@@ -14,6 +14,23 @@ return new class extends Migration
         Schema::create('posts', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->longText('content');
+            $table->json('content_json');
+            $table->text('excerpt')->nullable();
+            $table->enum('status', ['draft', 'published'])->default('draft');
+            $table->string('meta_title')->nullable();
+            $table->string('meta_description')->nullable();
+            $table->string('meta_keywords')->nullable();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('featured_image')->nullable();
+            $table->foreignId('category_id')->nullable()->constrained()->nullOnDelete();
+            $table->timestamp('published_at')->nullable();
+            $table->softDeletes();
+            $table->index('status');
+            $table->index('published_at');
+            $table->index('category_id');
         });
     }
 

--- a/laravel/database/migrations/2026_04_20_092426_create_tags_table.php
+++ b/laravel/database/migrations/2026_04_20_092426_create_tags_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tags');
+    }
+};

--- a/laravel/database/migrations/2026_04_20_092426_create_tags_table.php
+++ b/laravel/database/migrations/2026_04_20_092426_create_tags_table.php
@@ -14,6 +14,8 @@ return new class extends Migration
         Schema::create('tags', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
+            $table->string('name');
+            $table->string('slug')->unique();
         });
     }
 

--- a/laravel/database/migrations/2026_04_20_092427_create_post_tag_table.php
+++ b/laravel/database/migrations/2026_04_20_092427_create_post_tag_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('post_tag', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('post_tag');
+    }
+};

--- a/laravel/database/migrations/2026_04_20_092427_create_post_tag_table.php
+++ b/laravel/database/migrations/2026_04_20_092427_create_post_tag_table.php
@@ -12,8 +12,9 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('post_tag', function (Blueprint $table) {
-            $table->id();
-            $table->timestamps();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('tag_id')->constrained()->cascadeOnDelete();
+            $table->primary(['post_id','tag_id']);
         });
     }
 

--- a/laravel/tests/Feature/ContentMigrationsTest.php
+++ b/laravel/tests/Feature/ContentMigrationsTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class ContentMigrationsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_categories_table_has_expected_columns(): void
+    {
+        // Arrange + Act + Assert
+        $this->assertTrue(Schema::hasTable('categories'));
+        $this->assertTrue(Schema::hasColumns('categories', [
+            'id',
+            'name',
+            'slug',
+            'description',
+            'parent_id',
+            'created_at',
+            'updated_at',
+        ]));
+    }
+
+    public function test_tags_table_has_expected_columns(): void
+    {
+        $this->assertTrue(Schema::hasTable('tags'));
+        $this->assertTrue(Schema::hasColumns('tags', [
+            'id',
+            'name',
+            'slug',
+            'created_at',
+            'updated_at',
+        ]));
+    }
+
+    public function test_pages_table_has_expected_columns(): void
+    {
+        $this->assertTrue(Schema::hasTable('pages'));
+        $this->assertTrue(Schema::hasColumns('pages', [
+            'id',
+            'title',
+            'slug',
+            'content',
+            'content_json',
+            'excerpt',
+            'status',
+            'meta_title',
+            'meta_description',
+            'meta_keywords',
+            'user_id',
+            'published_at',
+            'deleted_at',
+            'created_at',
+            'updated_at',
+        ]));
+    }
+
+    public function test_posts_table_has_expected_columns(): void
+    {
+        $this->assertTrue(Schema::hasTable('posts'));
+        $this->assertTrue(Schema::hasColumns('posts', [
+            'id',
+            'title',
+            'slug',
+            'content',
+            'content_json',
+            'excerpt',
+            'status',
+            'meta_title',
+            'meta_description',
+            'meta_keywords',
+            'user_id',
+            'featured_image',
+            'category_id',
+            'published_at',
+            'deleted_at',
+            'created_at',
+            'updated_at',
+        ]));
+    }
+
+    public function test_post_tag_table_has_expected_columns(): void
+    {
+        $this->assertTrue(Schema::hasTable('post_tag'));
+        $this->assertTrue(Schema::hasColumns('post_tag', [
+            'post_id',
+            'tag_id',
+        ]));
+    }
+
+    public function test_pages_status_defaults_to_draft(): void
+    {
+        // Arrange
+        $column = Schema::getColumns('pages');
+        $status = collect($column)->firstWhere('name', 'status');
+
+        // Assert
+        $this->assertStringContainsString('draft', $status['default']);
+    }
+
+    public function test_posts_status_defaults_to_draft(): void
+    {
+        // Arrange
+        $column = Schema::getColumns('posts');
+        $status = collect($column)->firstWhere('name', 'status');
+
+        // Assert
+        $this->assertStringContainsString('draft', $status['default']);
+    }
+
+    public function test_categories_parent_id_is_nullable(): void
+    {
+        // Arrange
+        $columns = Schema::getColumns('categories');
+        $parentId = collect($columns)->firstWhere('name', 'parent_id');
+
+        // Assert
+        $this->assertTrue($parentId['nullable']);
+    }
+
+    public function test_pages_soft_deletes_column_is_nullable(): void
+    {
+        // Arrange
+        $columns = Schema::getColumns('pages');
+        $deletedAt = collect($columns)->firstWhere('name', 'deleted_at');
+
+        // Assert
+        $this->assertTrue($deletedAt['nullable']);
+    }
+
+    public function test_posts_soft_deletes_column_is_nullable(): void
+    {
+        // Arrange
+        $columns = Schema::getColumns('posts');
+        $deletedAt = collect($columns)->firstWhere('name', 'deleted_at');
+
+        // Assert
+        $this->assertTrue($deletedAt['nullable']);
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -67,26 +67,31 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 ### Stage 2 — Core Content `phase-2`
 > Full CRUD for pages, posts, categories, and tags.
 
-| # | Issue | Labels |
-|---|-------|--------|
-| [#70](https://github.com/Three-Hoops/Hoops-CMS/issues/70) | Add multilingual content support with spatie/laravel-translatable | `content`, `enhancement` |
-| [#2](https://github.com/Three-Hoops/Hoops-CMS/issues/2) | Phase 2: Core Content (Pages, Posts, Categories, Tags) | `content`, `enhancement` |
-| [#76](https://github.com/Three-Hoops/Hoops-CMS/issues/76) | Add parent_id to pages table for hierarchical page structure | `content`, `enhancement` |
-| [#85](https://github.com/Three-Hoops/Hoops-CMS/issues/85) | Add duplicate action for posts and pages | `content`, `enhancement` |
-| [#65](https://github.com/Three-Hoops/Hoops-CMS/issues/65) | Add per-post and per-page Open Graph / social meta fields | `content`, `enhancement` |
-| [#69](https://github.com/Three-Hoops/Hoops-CMS/issues/69) | Add featured/pinned flag to posts | `content`, `enhancement` |
-| [#17](https://github.com/Three-Hoops/Hoops-CMS/issues/17) | Add soft deletes to content models | `content` |
-| [#40](https://github.com/Three-Hoops/Hoops-CMS/issues/40) | Add database indexes to content migrations | `performance` |
-| [#43](https://github.com/Three-Hoops/Hoops-CMS/issues/43) | Handle slug collisions with auto-increment | `content` |
-| [#45](https://github.com/Three-Hoops/Hoops-CMS/issues/45) | Wrap multi-step writes in database transactions | `content` |
-| [#38](https://github.com/Three-Hoops/Hoops-CMS/issues/38) | Sanitise TipTap HTML output to prevent XSS | `security`, `content` |
-| [#68](https://github.com/Three-Hoops/Hoops-CMS/issues/68) | Add autosave for rich text editor to prevent data loss | `content`, `enhancement` |
-| [#110](https://github.com/Three-Hoops/Hoops-CMS/issues/110) | Warn users about unsaved changes before navigating away | `content`, `enhancement` |
-| [#58](https://github.com/Three-Hoops/Hoops-CMS/issues/58) | Bulk actions on content lists (publish, draft, delete) | `content`, `enhancement` |
-| [#75](https://github.com/Three-Hoops/Hoops-CMS/issues/75) | Add trash view and restore for soft-deleted content | `content`, `enhancement` |
-| [#32](https://github.com/Three-Hoops/Hoops-CMS/issues/32) | Add draft preview for posts and pages | `content`, `enhancement` |
-| [#72](https://github.com/Three-Hoops/Hoops-CMS/issues/72) | Add language switcher UI to post and page edit forms | `content`, `enhancement` |
-| [#66](https://github.com/Three-Hoops/Hoops-CMS/issues/66) | Write Vue component tests for admin UI components | `testing` |
+| Status | # | Issue | Labels |
+|--------|---|-------|--------|
+| ⬜ | [#2](https://github.com/Three-Hoops/Hoops-CMS/issues/2) | Phase 2: Core Content (Pages, Posts, Categories, Tags) — umbrella | `content`, `enhancement` |
+| ⬜ | [#156](https://github.com/Three-Hoops/Hoops-CMS/issues/156) | Create content migrations (categories, tags, pages, posts, post_tag) | `content`, `enhancement` |
+| ⬜ | [#157](https://github.com/Three-Hoops/Hoops-CMS/issues/157) | Add ContentStatus enum and content models (Category, Tag, Page, Post) | `content`, `enhancement` |
+| ⬜ | [#158](https://github.com/Three-Hoops/Hoops-CMS/issues/158) | Add controllers, form requests, and policies for content types | `content`, `enhancement` |
+| ⬜ | [#159](https://github.com/Three-Hoops/Hoops-CMS/issues/159) | Register admin resource routes for content types | `content`, `enhancement` |
+| ⬜ | [#160](https://github.com/Three-Hoops/Hoops-CMS/issues/160) | Build Vue pages and shared components for content management | `content`, `enhancement` |
+| ⬜ | [#76](https://github.com/Three-Hoops/Hoops-CMS/issues/76) | Add parent_id to pages table for hierarchical page structure | `content`, `enhancement` |
+| ⬜ | [#85](https://github.com/Three-Hoops/Hoops-CMS/issues/85) | Add duplicate action for posts and pages | `content`, `enhancement` |
+| ⬜ | [#65](https://github.com/Three-Hoops/Hoops-CMS/issues/65) | Add per-post and per-page Open Graph / social meta fields | `content`, `enhancement` |
+| ⬜ | [#69](https://github.com/Three-Hoops/Hoops-CMS/issues/69) | Add featured/pinned flag to posts | `content`, `enhancement` |
+| ⬜ | [#17](https://github.com/Three-Hoops/Hoops-CMS/issues/17) | Add soft deletes to content models | `content` |
+| ⬜ | [#40](https://github.com/Three-Hoops/Hoops-CMS/issues/40) | Add database indexes to content migrations | `performance` |
+| ⬜ | [#43](https://github.com/Three-Hoops/Hoops-CMS/issues/43) | Handle slug collisions with auto-increment | `content` |
+| ⬜ | [#45](https://github.com/Three-Hoops/Hoops-CMS/issues/45) | Wrap multi-step writes in database transactions | `content` |
+| ⬜ | [#38](https://github.com/Three-Hoops/Hoops-CMS/issues/38) | Sanitise TipTap HTML output to prevent XSS | `security`, `content` |
+| ⬜ | [#68](https://github.com/Three-Hoops/Hoops-CMS/issues/68) | Add autosave for rich text editor to prevent data loss | `content`, `enhancement` |
+| ⬜ | [#110](https://github.com/Three-Hoops/Hoops-CMS/issues/110) | Warn users about unsaved changes before navigating away | `content`, `enhancement` |
+| ⬜ | [#58](https://github.com/Three-Hoops/Hoops-CMS/issues/58) | Bulk actions on content lists (publish, draft, delete) | `content`, `enhancement` |
+| ⬜ | [#75](https://github.com/Three-Hoops/Hoops-CMS/issues/75) | Add trash view and restore for soft-deleted content | `content`, `enhancement` |
+| ⬜ | [#32](https://github.com/Three-Hoops/Hoops-CMS/issues/32) | Add draft preview for posts and pages | `content`, `enhancement` |
+| ⬜ | [#72](https://github.com/Three-Hoops/Hoops-CMS/issues/72) | Add language switcher UI to post and page edit forms | `content`, `enhancement` |
+| ⬜ | [#66](https://github.com/Three-Hoops/Hoops-CMS/issues/66) | Write Vue component tests for admin UI components | `testing` |
+| ⬜ | [#70](https://github.com/Three-Hoops/Hoops-CMS/issues/70) | Add multilingual content support with spatie/laravel-translatable | `content`, `enhancement` |
 
 ---
 


### PR DESCRIPTION
Closes #156

## Summary
- Adds migrations for all Phase 2 content tables: `categories`, `tags`, `pages`, `posts`, and `post_tag` pivot
- Includes soft deletes on `pages` and `posts` (#17), database indexes on slug/status/published_at/category_id/parent_id (#40)
- 10 feature tests verifying table structure, column presence, nullable constraints, and status defaults

## Test plan
- [x] `php artisan migrate:fresh` completes without errors
- [x] `php artisan test --filter ContentMigrationsTest` — 10/10 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)