### PR TITLE
Add controllers, form requests, and policies for content types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,3 +164,13 @@ This project follows **GitHub Flow**: one branch per feature/fix, PR into `main`
 - `main` is always deployable — never commit directly to it.
 - Open a PR for every change; CI must pass before merging.
 - Branch protection on `main` is enabled: PR + 1 approval required, force pushes blocked. Required status checks will be added once CI is configured (issue #9).
+
+### Commit granularity
+
+Keep commits small and focused — one logical change per commit. This makes diffs easy to review and bisect. Examples of good commit boundaries:
+
+- One commit per new file type (e.g. policies separate from form requests, controllers separate from tests)
+- Config/tooling changes in their own commit, not bundled with feature code
+- `plan.md` status updates in their own commit, separate from implementation
+
+Never bundle unrelated changes into a single commit. If two things would be described with "and" in the commit message, they belong in separate commits.

--- a/laravel/app/Http/Controllers/Admin/CategoryController.php
+++ b/laravel/app/Http/Controllers/Admin/CategoryController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Enums\FlashType;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\StoreCategory;
+use App\Http\Requests\Admin\UpdateCategory;
+use App\Models\Category;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Str;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class CategoryController extends Controller
+{
+    public function index(): Response
+    {
+        $this->authorize('viewAny', Category::class);
+
+        $categories = Category::with('parent')
+            ->orderBy('name')
+            ->paginate(15);
+
+        return Inertia::render('Admin/Categories/Index', [
+            'categories' => $categories,
+        ]);
+    }
+
+    public function create(): Response
+    {
+        $this->authorize('create', Category::class);
+
+        return Inertia::render('Admin/Categories/Create', [
+            'parents' => Category::orderBy('name')->get(['id', 'name']),
+        ]);
+    }
+
+    public function store(StoreCategory $request): RedirectResponse
+    {
+        $validated = $request->validated();
+        $validated['slug'] ??= Str::slug($validated['name']);
+
+        Category::create($validated);
+
+        return redirect()
+            ->route('admin.categories.index')
+            ->with(FlashType::Success->value, 'Category created successfully.');
+    }
+
+    public function edit(Category $category): Response
+    {
+        $this->authorize('update', $category);
+
+        return Inertia::render('Admin/Categories/Edit', [
+            'category' => $category->load('parent'),
+            'parents'  => Category::where('id', '!=', $category->id)
+                ->orderBy('name')
+                ->get(['id', 'name']),
+        ]);
+    }
+
+    public function update(UpdateCategory $request, Category $category): RedirectResponse
+    {
+        $validated = $request->validated();
+        $validated['slug'] ??= Str::slug($validated['name']);
+
+        $category->update($validated);
+
+        return redirect()
+            ->route('admin.categories.index')
+            ->with(FlashType::Success->value, 'Category updated successfully.');
+    }
+
+    public function destroy(Category $category): RedirectResponse
+    {
+        $this->authorize('delete', $category);
+
+        $category->delete();
+
+        return redirect()
+            ->route('admin.categories.index')
+            ->with(FlashType::Success->value, 'Category deleted successfully.');
+    }
+}

--- a/laravel/app/Http/Controllers/Admin/DashboardController.php
+++ b/laravel/app/Http/Controllers/Admin/DashboardController.php
@@ -2,7 +2,12 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Enums\ContentStatus;
 use App\Http\Controllers\Controller;
+use App\Models\Category;
+use App\Models\Page;
+use App\Models\Post;
+use App\Models\Tag;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -10,9 +15,25 @@ class DashboardController extends Controller
 {
     public function index(): Response
     {
-        // TODO: pass real stats once content models exist
         return Inertia::render('Admin/Dashboard', [
-            'stats' => [],
+            'stats' => [
+                'posts' => [
+                    'total'     => Post::count(),
+                    'published' => Post::where('status', ContentStatus::Published)->count(),
+                    'draft'     => Post::where('status', ContentStatus::Draft)->count(),
+                ],
+                'pages' => [
+                    'total'     => Page::count(),
+                    'published' => Page::where('status', ContentStatus::Published)->count(),
+                    'draft'     => Page::where('status', ContentStatus::Draft)->count(),
+                ],
+                'categories'   => Category::count(),
+                'tags'         => Tag::count(),
+                'recent_posts' => Post::with('author')
+                    ->latest()
+                    ->limit(5)
+                    ->get(['id', 'title', 'status', 'published_at', 'created_at', 'user_id']),
+            ],
         ]);
     }
 }

--- a/laravel/app/Http/Controllers/Admin/PageController.php
+++ b/laravel/app/Http/Controllers/Admin/PageController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Enums\ContentStatus;
+use App\Enums\FlashType;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\StorePage;
+use App\Http\Requests\Admin\UpdatePage;
+use App\Models\Page;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Str;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class PageController extends Controller
+{
+    public function index(): Response
+    {
+        $this->authorize('viewAny', Page::class);
+
+        $pages = Page::with('author')
+            ->latest()
+            ->paginate(15);
+
+        return Inertia::render('Admin/Pages/Index', [
+            'pages' => $pages,
+        ]);
+    }
+
+    public function create(): Response
+    {
+        $this->authorize('create', Page::class);
+
+        return Inertia::render('Admin/Pages/Create');
+    }
+
+    public function store(StorePage $request): RedirectResponse
+    {
+        $validated = $request->validated();
+        $validated['slug']         ??= Str::slug($validated['title']);
+        $validated['content_json'] ??= [];
+        $validated['user_id']        = $request->user()->id;
+
+        if ($validated['status'] === ContentStatus::Published->value && empty($validated['published_at'])) {
+            $validated['published_at'] = now();
+        }
+
+        Page::create($validated);
+
+        return redirect()
+            ->route('admin.pages.index')
+            ->with(FlashType::Success->value, 'Page created successfully.');
+    }
+
+    public function edit(Page $page): Response
+    {
+        $this->authorize('update', $page);
+
+        return Inertia::render('Admin/Pages/Edit', [
+            'page' => $page->load('author'),
+        ]);
+    }
+
+    public function update(UpdatePage $request, Page $page): RedirectResponse
+    {
+        $validated = $request->validated();
+        $validated['slug']         ??= Str::slug($validated['title']);
+        $validated['content_json'] ??= [];
+
+        if (
+            $validated['status'] === ContentStatus::Published->value
+            && is_null($page->published_at)
+            && empty($validated['published_at'])
+        ) {
+            $validated['published_at'] = now();
+        }
+
+        $page->update($validated);
+
+        return redirect()
+            ->route('admin.pages.index')
+            ->with(FlashType::Success->value, 'Page updated successfully.');
+    }
+
+    public function destroy(Page $page): RedirectResponse
+    {
+        $this->authorize('delete', $page);
+
+        $page->delete();
+
+        return redirect()
+            ->route('admin.pages.index')
+            ->with(FlashType::Success->value, 'Page deleted successfully.');
+    }
+}

--- a/laravel/app/Http/Controllers/Admin/PostController.php
+++ b/laravel/app/Http/Controllers/Admin/PostController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Enums\ContentStatus;
+use App\Enums\FlashType;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\StorePost;
+use App\Http\Requests\Admin\UpdatePost;
+use App\Models\Category;
+use App\Models\Post;
+use App\Models\Tag;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class PostController extends Controller
+{
+    public function index(): Response
+    {
+        $this->authorize('viewAny', Post::class);
+
+        $posts = Post::with(['author', 'category', 'tags'])
+            ->latest()
+            ->paginate(15);
+
+        return Inertia::render('Admin/Posts/Index', [
+            'posts' => $posts,
+        ]);
+    }
+
+    public function create(): Response
+    {
+        $this->authorize('create', Post::class);
+
+        return Inertia::render('Admin/Posts/Create', [
+            'categories' => Category::orderBy('name')->get(['id', 'name']),
+            'tags'       => Tag::orderBy('name')->get(['id', 'name']),
+        ]);
+    }
+
+    public function store(StorePost $request): RedirectResponse
+    {
+        $validated = $request->validated();
+        $tagIds    = Arr::pull($validated, 'tag_ids', []);
+
+        $validated['slug']         ??= Str::slug($validated['title']);
+        $validated['content_json'] ??= [];
+        $validated['user_id']        = $request->user()->id;
+
+        if ($validated['status'] === ContentStatus::Published->value && empty($validated['published_at'])) {
+            $validated['published_at'] = now();
+        }
+
+        $post = Post::create($validated);
+        $post->tags()->sync($tagIds);
+
+        return redirect()
+            ->route('admin.posts.index')
+            ->with(FlashType::Success->value, 'Post created successfully.');
+    }
+
+    public function edit(Post $post): Response
+    {
+        $this->authorize('update', $post);
+
+        return Inertia::render('Admin/Posts/Edit', [
+            'post'       => $post->load(['author', 'category', 'tags']),
+            'categories' => Category::orderBy('name')->get(['id', 'name']),
+            'tags'       => Tag::orderBy('name')->get(['id', 'name']),
+        ]);
+    }
+
+    public function update(UpdatePost $request, Post $post): RedirectResponse
+    {
+        $validated = $request->validated();
+        $tagIds    = Arr::pull($validated, 'tag_ids', []);
+
+        $validated['slug']         ??= Str::slug($validated['title']);
+        $validated['content_json'] ??= [];
+
+        if (
+            $validated['status'] === ContentStatus::Published->value
+            && is_null($post->published_at)
+            && empty($validated['published_at'])
+        ) {
+            $validated['published_at'] = now();
+        }
+
+        $post->update($validated);
+        $post->tags()->sync($tagIds);
+
+        return redirect()
+            ->route('admin.posts.index')
+            ->with(FlashType::Success->value, 'Post updated successfully.');
+    }
+
+    public function destroy(Post $post): RedirectResponse
+    {
+        $this->authorize('delete', $post);
+
+        $post->delete();
+
+        return redirect()
+            ->route('admin.posts.index')
+            ->with(FlashType::Success->value, 'Post deleted successfully.');
+    }
+}

--- a/laravel/app/Http/Controllers/Admin/TagController.php
+++ b/laravel/app/Http/Controllers/Admin/TagController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Enums\FlashType;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\StoreTag;
+use App\Http\Requests\Admin\UpdateTag;
+use App\Models\Tag;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Str;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class TagController extends Controller
+{
+    public function index(): Response
+    {
+        $this->authorize('viewAny', Tag::class);
+
+        $tags = Tag::orderBy('name')->paginate(15);
+
+        return Inertia::render('Admin/Tags/Index', [
+            'tags' => $tags,
+        ]);
+    }
+
+    public function store(StoreTag $request): RedirectResponse
+    {
+        $validated = $request->validated();
+        $validated['slug'] ??= Str::slug($validated['name']);
+
+        Tag::create($validated);
+
+        return redirect()
+            ->route('admin.tags.index')
+            ->with(FlashType::Success->value, 'Tag created successfully.');
+    }
+
+    public function update(UpdateTag $request, Tag $tag): RedirectResponse
+    {
+        $validated = $request->validated();
+        $validated['slug'] ??= Str::slug($validated['name']);
+
+        $tag->update($validated);
+
+        return redirect()
+            ->route('admin.tags.index')
+            ->with(FlashType::Success->value, 'Tag updated successfully.');
+    }
+
+    public function destroy(Tag $tag): RedirectResponse
+    {
+        $this->authorize('delete', $tag);
+
+        $tag->delete();
+
+        return redirect()
+            ->route('admin.tags.index')
+            ->with(FlashType::Success->value, 'Tag deleted successfully.');
+    }
+}

--- a/laravel/app/Http/Controllers/Controller.php
+++ b/laravel/app/Http/Controllers/Controller.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
 abstract class Controller
 {
-    //
+    use AuthorizesRequests;
 }

--- a/laravel/app/Http/Requests/Admin/StoreCategory.php
+++ b/laravel/app/Http/Requests/Admin/StoreCategory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use App\Models\Category;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreCategory extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('create', Category::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name'        => ['required', 'string', 'max:255'],
+            'slug'        => ['nullable', 'string', 'max:255', Rule::unique('categories', 'slug')],
+            'description' => ['nullable', 'string', 'max:1000'],
+            'parent_id'   => ['nullable', 'integer', Rule::exists('categories', 'id')],
+        ];
+    }
+}

--- a/laravel/app/Http/Requests/Admin/StorePage.php
+++ b/laravel/app/Http/Requests/Admin/StorePage.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use App\Enums\ContentStatus;
+use App\Models\Page;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StorePage extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('create', Page::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title'            => ['required', 'string', 'max:255'],
+            'slug'             => ['nullable', 'string', 'max:255', Rule::unique('pages', 'slug')],
+            'content'          => ['required', 'string'],
+            'content_json'     => ['nullable', 'array'],
+            'excerpt'          => ['nullable', 'string', 'max:1000'],
+            'status'           => ['required', Rule::enum(ContentStatus::class)],
+            'meta_title'       => ['nullable', 'string', 'max:255'],
+            'meta_description' => ['nullable', 'string', 'max:255'],
+            'meta_keywords'    => ['nullable', 'string', 'max:255'],
+            'published_at'     => ['nullable', 'date'],
+        ];
+    }
+}

--- a/laravel/app/Http/Requests/Admin/StorePost.php
+++ b/laravel/app/Http/Requests/Admin/StorePost.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use App\Enums\ContentStatus;
+use App\Models\Post;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StorePost extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('create', Post::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title'            => ['required', 'string', 'max:255'],
+            'slug'             => ['nullable', 'string', 'max:255', Rule::unique('posts', 'slug')],
+            'content'          => ['required', 'string'],
+            'content_json'     => ['nullable', 'array'],
+            'excerpt'          => ['nullable', 'string', 'max:1000'],
+            'status'           => ['required', Rule::enum(ContentStatus::class)],
+            'meta_title'       => ['nullable', 'string', 'max:255'],
+            'meta_description' => ['nullable', 'string', 'max:255'],
+            'meta_keywords'    => ['nullable', 'string', 'max:255'],
+            'published_at'     => ['nullable', 'date'],
+            'featured_image'   => ['nullable', 'string', 'max:255'],
+            'category_id'      => ['nullable', 'integer', Rule::exists('categories', 'id')],
+            'tag_ids'          => ['nullable', 'array'],
+            'tag_ids.*'        => ['integer', Rule::exists('tags', 'id')],
+        ];
+    }
+}

--- a/laravel/app/Http/Requests/Admin/StoreTag.php
+++ b/laravel/app/Http/Requests/Admin/StoreTag.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use App\Models\Tag;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreTag extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('create', Tag::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255', Rule::unique('tags', 'slug')],
+        ];
+    }
+}

--- a/laravel/app/Http/Requests/Admin/UpdateCategory.php
+++ b/laravel/app/Http/Requests/Admin/UpdateCategory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateCategory extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('update', $this->route('category'));
+    }
+
+    public function rules(): array
+    {
+        $categoryId = $this->route('category')->id;
+
+        return [
+            'name'        => ['required', 'string', 'max:255'],
+            'slug'        => ['nullable', 'string', 'max:255', Rule::unique('categories', 'slug')->ignore($categoryId)],
+            'description' => ['nullable', 'string', 'max:1000'],
+            'parent_id'   => [
+                'nullable',
+                'integer',
+                Rule::exists('categories', 'id'),
+                Rule::notIn([$categoryId]),
+            ],
+        ];
+    }
+}

--- a/laravel/app/Http/Requests/Admin/UpdatePage.php
+++ b/laravel/app/Http/Requests/Admin/UpdatePage.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use App\Enums\ContentStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdatePage extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('update', $this->route('page'));
+    }
+
+    public function rules(): array
+    {
+        $pageId = $this->route('page')->id;
+
+        return [
+            'title'            => ['required', 'string', 'max:255'],
+            'slug'             => ['nullable', 'string', 'max:255', Rule::unique('pages', 'slug')->ignore($pageId)],
+            'content'          => ['required', 'string'],
+            'content_json'     => ['nullable', 'array'],
+            'excerpt'          => ['nullable', 'string', 'max:1000'],
+            'status'           => ['required', Rule::enum(ContentStatus::class)],
+            'meta_title'       => ['nullable', 'string', 'max:255'],
+            'meta_description' => ['nullable', 'string', 'max:255'],
+            'meta_keywords'    => ['nullable', 'string', 'max:255'],
+            'published_at'     => ['nullable', 'date'],
+        ];
+    }
+}

--- a/laravel/app/Http/Requests/Admin/UpdatePost.php
+++ b/laravel/app/Http/Requests/Admin/UpdatePost.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use App\Enums\ContentStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdatePost extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('update', $this->route('post'));
+    }
+
+    public function rules(): array
+    {
+        $postId = $this->route('post')->id;
+
+        return [
+            'title'            => ['required', 'string', 'max:255'],
+            'slug'             => ['nullable', 'string', 'max:255', Rule::unique('posts', 'slug')->ignore($postId)],
+            'content'          => ['required', 'string'],
+            'content_json'     => ['nullable', 'array'],
+            'excerpt'          => ['nullable', 'string', 'max:1000'],
+            'status'           => ['required', Rule::enum(ContentStatus::class)],
+            'meta_title'       => ['nullable', 'string', 'max:255'],
+            'meta_description' => ['nullable', 'string', 'max:255'],
+            'meta_keywords'    => ['nullable', 'string', 'max:255'],
+            'published_at'     => ['nullable', 'date'],
+            'featured_image'   => ['nullable', 'string', 'max:255'],
+            'category_id'      => ['nullable', 'integer', Rule::exists('categories', 'id')],
+            'tag_ids'          => ['nullable', 'array'],
+            'tag_ids.*'        => ['integer', Rule::exists('tags', 'id')],
+        ];
+    }
+}

--- a/laravel/app/Http/Requests/Admin/UpdateTag.php
+++ b/laravel/app/Http/Requests/Admin/UpdateTag.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateTag extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('update', $this->route('tag'));
+    }
+
+    public function rules(): array
+    {
+        $tagId = $this->route('tag')->id;
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255', Rule::unique('tags', 'slug')->ignore($tagId)],
+        ];
+    }
+}

--- a/laravel/app/Policies/CategoryPolicy.php
+++ b/laravel/app/Policies/CategoryPolicy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Category;
+use App\Models\User;
+
+class CategoryPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, Category $category): bool
+    {
+        return $user->role->canEdit();
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->role->canEdit();
+    }
+
+    public function update(User $user, Category $category): bool
+    {
+        return $user->role->canEdit();
+    }
+
+    public function delete(User $user, Category $category): bool
+    {
+        return $user->role->canEdit();
+    }
+}

--- a/laravel/app/Policies/PagePolicy.php
+++ b/laravel/app/Policies/PagePolicy.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\UserRole;
+use App\Models\Page;
+use App\Models\User;
+
+class PagePolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, Page $page): bool
+    {
+        return $user->role->canEdit();
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->role->canEdit();
+    }
+
+    public function update(User $user, Page $page): bool
+    {
+        return $user->role === UserRole::SuperAdmin
+            || ($user->role === UserRole::Editor && $page->user_id === $user->id);
+    }
+
+    public function delete(User $user, Page $page): bool
+    {
+        return $user->role === UserRole::SuperAdmin
+            || ($user->role === UserRole::Editor && $page->user_id === $user->id);
+    }
+
+    public function restore(User $user, Page $page): bool
+    {
+        return $user->role === UserRole::SuperAdmin
+            || ($user->role === UserRole::Editor && $page->user_id === $user->id);
+    }
+
+    public function forceDelete(User $user, Page $page): bool
+    {
+        return $user->role === UserRole::SuperAdmin;
+    }
+}

--- a/laravel/app/Policies/PostPolicy.php
+++ b/laravel/app/Policies/PostPolicy.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\UserRole;
+use App\Models\Post;
+use App\Models\User;
+
+class PostPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, Post $post): bool
+    {
+        return $user->role->canEdit();
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->role->canEdit();
+    }
+
+    public function update(User $user, Post $post): bool
+    {
+        return $user->role === UserRole::SuperAdmin
+            || ($user->role === UserRole::Editor && $post->user_id === $user->id);
+    }
+
+    public function delete(User $user, Post $post): bool
+    {
+        return $user->role === UserRole::SuperAdmin
+            || ($user->role === UserRole::Editor && $post->user_id === $user->id);
+    }
+
+    public function restore(User $user, Post $post): bool
+    {
+        return $user->role === UserRole::SuperAdmin
+            || ($user->role === UserRole::Editor && $post->user_id === $user->id);
+    }
+
+    public function forceDelete(User $user, Post $post): bool
+    {
+        return $user->role === UserRole::SuperAdmin;
+    }
+}

--- a/laravel/app/Policies/TagPolicy.php
+++ b/laravel/app/Policies/TagPolicy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Tag;
+use App\Models\User;
+
+class TagPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, Tag $tag): bool
+    {
+        return $user->role->canEdit();
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->role->canEdit();
+    }
+
+    public function update(User $user, Tag $tag): bool
+    {
+        return $user->role->canEdit();
+    }
+
+    public function delete(User $user, Tag $tag): bool
+    {
+        return $user->role->canEdit();
+    }
+}

--- a/laravel/tests/Feature/Admin/CategoryControllerTest.php
+++ b/laravel/tests/Feature/Admin/CategoryControllerTest.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\UserRole;
+use App\Models\Category;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CategoryControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ─── index ───────────────────────────────────────────────────────────────
+
+    public function test_all_roles_can_view_categories_index(): void
+    {
+        // Arrange
+        $this->withoutVite();
+
+        foreach ([UserRole::SuperAdmin, UserRole::Editor, UserRole::Viewer] as $role) {
+            $user = User::factory()->create(['role' => $role]);
+
+            // Act + Assert
+            $this->actingAs($user)->get('/admin/categories')->assertOk();
+        }
+    }
+
+    public function test_guest_is_redirected_from_categories_index(): void
+    {
+        // Act + Assert
+        $this->get('/admin/categories')->assertRedirect(route('admin.login'));
+    }
+
+    // ─── store ────────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_create_category(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act
+        $response = $this->actingAs($user)->post('/admin/categories', [
+            'name' => 'Technology',
+        ]);
+
+        // Assert
+        $response->assertRedirect('/admin/categories');
+        $this->assertDatabaseHas('categories', ['name' => 'Technology', 'slug' => 'technology']);
+    }
+
+    public function test_editor_can_create_category(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Editor]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/categories', ['name' => 'Science'])
+            ->assertRedirect('/admin/categories');
+    }
+
+    public function test_viewer_cannot_create_category(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Viewer]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/categories', ['name' => 'Hacked'])
+            ->assertForbidden();
+    }
+
+    public function test_store_generates_slug_from_name(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act
+        $this->actingAs($user)->post('/admin/categories', ['name' => 'Web Development']);
+
+        // Assert
+        $this->assertDatabaseHas('categories', ['slug' => 'web-development']);
+    }
+
+    public function test_store_accepts_valid_parent_id(): void
+    {
+        // Arrange
+        $user   = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $parent = Category::factory()->create();
+
+        // Act
+        $this->actingAs($user)->post('/admin/categories', [
+            'name'      => 'Child Category',
+            'parent_id' => $parent->id,
+        ]);
+
+        // Assert
+        $this->assertDatabaseHas('categories', ['name' => 'Child Category', 'parent_id' => $parent->id]);
+    }
+
+    public function test_store_rejects_invalid_parent_id(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/categories', ['name' => 'Child', 'parent_id' => 99999])
+            ->assertSessionHasErrors('parent_id');
+    }
+
+    public function test_store_rejects_duplicate_slug(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        Category::factory()->create(['slug' => 'existing']);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/categories', ['name' => 'Whatever', 'slug' => 'existing'])
+            ->assertSessionHasErrors('slug');
+    }
+
+    // ─── update ───────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_update_category(): void
+    {
+        // Arrange
+        $user     = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $category = Category::factory()->create(['name' => 'Old Name']);
+
+        // Act
+        $this->actingAs($user)->put("/admin/categories/{$category->id}", [
+            'name' => 'New Name',
+        ]);
+
+        // Assert
+        $this->assertDatabaseHas('categories', ['id' => $category->id, 'name' => 'New Name']);
+    }
+
+    public function test_editor_can_update_category(): void
+    {
+        // Arrange
+        $user     = User::factory()->create(['role' => UserRole::Editor]);
+        $category = Category::factory()->create();
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->put("/admin/categories/{$category->id}", ['name' => 'Updated'])
+            ->assertRedirect('/admin/categories');
+    }
+
+    public function test_viewer_cannot_update_category(): void
+    {
+        // Arrange
+        $user     = User::factory()->create(['role' => UserRole::Viewer]);
+        $category = Category::factory()->create();
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->put("/admin/categories/{$category->id}", ['name' => 'Hacked'])
+            ->assertForbidden();
+    }
+
+    public function test_update_ignores_own_slug_in_uniqueness_check(): void
+    {
+        // Arrange
+        $user     = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $category = Category::factory()->create(['slug' => 'my-category']);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->put("/admin/categories/{$category->id}", [
+                'name' => 'My Category',
+                'slug' => 'my-category',
+            ])
+            ->assertRedirect('/admin/categories');
+    }
+
+    public function test_update_rejects_self_as_parent(): void
+    {
+        // Arrange
+        $user     = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $category = Category::factory()->create();
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->put("/admin/categories/{$category->id}", [
+                'name'      => 'Self Parent',
+                'parent_id' => $category->id,
+            ])
+            ->assertSessionHasErrors('parent_id');
+    }
+
+    // ─── destroy ──────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_delete_category(): void
+    {
+        // Arrange
+        $user     = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $category = Category::factory()->create();
+
+        // Act
+        $this->actingAs($user)->delete("/admin/categories/{$category->id}");
+
+        // Assert
+        $this->assertDatabaseMissing('categories', ['id' => $category->id]);
+    }
+
+    public function test_editor_can_delete_category(): void
+    {
+        // Arrange
+        $user     = User::factory()->create(['role' => UserRole::Editor]);
+        $category = Category::factory()->create();
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->delete("/admin/categories/{$category->id}")
+            ->assertRedirect('/admin/categories');
+    }
+
+    public function test_viewer_cannot_delete_category(): void
+    {
+        // Arrange
+        $user     = User::factory()->create(['role' => UserRole::Viewer]);
+        $category = Category::factory()->create();
+
+        // Act + Assert
+        $this->actingAs($user)->delete("/admin/categories/{$category->id}")->assertForbidden();
+    }
+}

--- a/laravel/tests/Feature/Admin/DashboardStatsTest.php
+++ b/laravel/tests/Feature/Admin/DashboardStatsTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\ContentStatus;
+use App\Enums\UserRole;
+use App\Models\Category;
+use App\Models\Page;
+use App\Models\Post;
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DashboardStatsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutVite();
+        $this->admin = User::factory()->create(['role' => UserRole::SuperAdmin]);
+    }
+
+    public function test_dashboard_returns_post_counts(): void
+    {
+        // Arrange
+        Post::factory()->count(3)->create(['status' => ContentStatus::Published, 'user_id' => $this->admin->id]);
+        Post::factory()->count(2)->create(['status' => ContentStatus::Draft, 'user_id' => $this->admin->id]);
+
+        // Act + Assert
+        $this->actingAs($this->admin)
+            ->get('/admin')
+            ->assertInertia(fn ($page) => $page
+                ->where('stats.posts.total', 5)
+                ->where('stats.posts.published', 3)
+                ->where('stats.posts.draft', 2)
+            );
+    }
+
+    public function test_dashboard_returns_page_counts(): void
+    {
+        // Arrange
+        Page::factory()->count(2)->create(['status' => ContentStatus::Published, 'user_id' => $this->admin->id]);
+        Page::factory()->count(1)->create(['status' => ContentStatus::Draft, 'user_id' => $this->admin->id]);
+
+        // Act + Assert
+        $this->actingAs($this->admin)
+            ->get('/admin')
+            ->assertInertia(fn ($page) => $page
+                ->where('stats.pages.total', 3)
+                ->where('stats.pages.published', 2)
+                ->where('stats.pages.draft', 1)
+            );
+    }
+
+    public function test_dashboard_returns_category_and_tag_counts(): void
+    {
+        // Arrange
+        Category::factory()->count(4)->create();
+        Tag::factory()->count(6)->create();
+
+        // Act + Assert
+        $this->actingAs($this->admin)
+            ->get('/admin')
+            ->assertInertia(fn ($page) => $page
+                ->where('stats.categories', 4)
+                ->where('stats.tags', 6)
+            );
+    }
+
+    public function test_dashboard_returns_five_recent_posts(): void
+    {
+        // Arrange
+        Post::factory()->count(7)->create(['user_id' => $this->admin->id]);
+
+        // Act + Assert
+        $this->actingAs($this->admin)
+            ->get('/admin')
+            ->assertInertia(fn ($page) => $page
+                ->has('stats.recent_posts', 5)
+            );
+    }
+
+    public function test_dashboard_stats_do_not_count_soft_deleted_posts(): void
+    {
+        // Arrange
+        $post = Post::factory()->create(['user_id' => $this->admin->id]);
+        $post->delete();
+
+        // Act + Assert
+        $this->actingAs($this->admin)
+            ->get('/admin')
+            ->assertInertia(fn ($page) => $page
+                ->where('stats.posts.total', 0)
+            );
+    }
+
+    public function test_dashboard_stats_do_not_count_soft_deleted_pages(): void
+    {
+        // Arrange
+        $page = Page::factory()->create(['user_id' => $this->admin->id]);
+        $page->delete();
+
+        // Act + Assert
+        $this->actingAs($this->admin)
+            ->get('/admin')
+            ->assertInertia(fn ($page) => $page
+                ->where('stats.pages.total', 0)
+            );
+    }
+}

--- a/laravel/tests/Feature/Admin/PageControllerTest.php
+++ b/laravel/tests/Feature/Admin/PageControllerTest.php
@@ -1,0 +1,461 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\ContentStatus;
+use App\Enums\UserRole;
+use App\Models\Page;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PageControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ─── index ───────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_view_pages_index(): void
+    {
+        // Arrange
+        $this->withoutVite();
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->get('/admin/pages')
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page->component('Admin/Pages/Index'));
+    }
+
+    public function test_editor_can_view_pages_index(): void
+    {
+        // Arrange
+        $this->withoutVite();
+        $user = User::factory()->create(['role' => UserRole::Editor]);
+
+        // Act + Assert
+        $this->actingAs($user)->get('/admin/pages')->assertOk();
+    }
+
+    public function test_viewer_can_view_pages_index(): void
+    {
+        // Arrange
+        $this->withoutVite();
+        $user = User::factory()->create(['role' => UserRole::Viewer]);
+
+        // Act + Assert
+        $this->actingAs($user)->get('/admin/pages')->assertOk();
+    }
+
+    public function test_guest_is_redirected_from_pages_index(): void
+    {
+        // Act + Assert
+        $this->get('/admin/pages')->assertRedirect(route('admin.login'));
+    }
+
+    // ─── create ───────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_view_create_page_form(): void
+    {
+        // Arrange
+        $this->withoutVite();
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->get('/admin/pages/create')
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page->component('Admin/Pages/Create'));
+    }
+
+    public function test_viewer_cannot_view_create_page_form(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Viewer]);
+
+        // Act + Assert
+        $this->actingAs($user)->get('/admin/pages/create')->assertForbidden();
+    }
+
+    // ─── store ────────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_create_page(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act
+        $response = $this->actingAs($user)->post('/admin/pages', [
+            'title'   => 'My Test Page',
+            'content' => 'Some content here',
+            'status'  => 'draft',
+        ]);
+
+        // Assert
+        $response->assertRedirect('/admin/pages');
+        $this->assertDatabaseHas('pages', [
+            'title'   => 'My Test Page',
+            'slug'    => 'my-test-page',
+            'user_id' => $user->id,
+            'status'  => 'draft',
+        ]);
+    }
+
+    public function test_editor_can_create_page(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Editor]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/pages', [
+                'title'   => 'Editor Page',
+                'content' => 'Content',
+                'status'  => 'draft',
+            ])
+            ->assertRedirect('/admin/pages');
+
+        $this->assertDatabaseHas('pages', ['title' => 'Editor Page', 'user_id' => $user->id]);
+    }
+
+    public function test_viewer_cannot_create_page(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Viewer]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/pages', [
+                'title'   => 'Viewer Page',
+                'content' => 'Content',
+                'status'  => 'draft',
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_store_generates_slug_from_title_when_not_provided(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act
+        $this->actingAs($user)->post('/admin/pages', [
+            'title'   => 'Hello World Page',
+            'content' => 'Body',
+            'status'  => 'draft',
+        ]);
+
+        // Assert
+        $this->assertDatabaseHas('pages', ['slug' => 'hello-world-page']);
+    }
+
+    public function test_store_uses_provided_slug(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act
+        $this->actingAs($user)->post('/admin/pages', [
+            'title'   => 'Hello World Page',
+            'slug'    => 'custom-slug',
+            'content' => 'Body',
+            'status'  => 'draft',
+        ]);
+
+        // Assert
+        $this->assertDatabaseHas('pages', ['slug' => 'custom-slug']);
+    }
+
+    public function test_store_sets_published_at_when_publishing_for_first_time(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act
+        $this->actingAs($user)->post('/admin/pages', [
+            'title'   => 'Published Page',
+            'content' => 'Content',
+            'status'  => 'published',
+        ]);
+
+        // Assert
+        $this->assertNotNull(Page::first()->published_at);
+    }
+
+    public function test_store_does_not_override_explicit_published_at(): void
+    {
+        // Arrange
+        $user        = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $publishedAt = '2025-01-15 10:00:00';
+
+        // Act
+        $this->actingAs($user)->post('/admin/pages', [
+            'title'        => 'Scheduled Page',
+            'content'      => 'Content',
+            'status'       => 'published',
+            'published_at' => $publishedAt,
+        ]);
+
+        // Assert
+        $this->assertDatabaseHas('pages', ['published_at' => $publishedAt]);
+    }
+
+    public function test_store_requires_title(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/pages', ['content' => 'Body', 'status' => 'draft'])
+            ->assertSessionHasErrors('title');
+    }
+
+    public function test_store_requires_content(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/pages', ['title' => 'Title', 'status' => 'draft'])
+            ->assertSessionHasErrors('content');
+    }
+
+    public function test_store_requires_valid_status(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/pages', ['title' => 'Title', 'content' => 'Body', 'status' => 'invalid'])
+            ->assertSessionHasErrors('status');
+    }
+
+    public function test_store_rejects_duplicate_slug(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        Page::factory()->create(['slug' => 'existing-slug']);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/pages', [
+                'title'   => 'Title',
+                'slug'    => 'existing-slug',
+                'content' => 'Body',
+                'status'  => 'draft',
+            ])
+            ->assertSessionHasErrors('slug');
+    }
+
+    // ─── edit ─────────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_view_edit_page_form(): void
+    {
+        // Arrange
+        $this->withoutVite();
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $page = Page::factory()->create();
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->get("/admin/pages/{$page->id}/edit")
+            ->assertOk()
+            ->assertInertia(fn ($p) => $p->component('Admin/Pages/Edit'));
+    }
+
+    public function test_editor_can_view_own_pages_edit_form(): void
+    {
+        // Arrange
+        $this->withoutVite();
+        $user = User::factory()->create(['role' => UserRole::Editor]);
+        $page = Page::factory()->create(['user_id' => $user->id]);
+
+        // Act + Assert
+        $this->actingAs($user)->get("/admin/pages/{$page->id}/edit")->assertOk();
+    }
+
+    public function test_editor_cannot_view_other_users_edit_form(): void
+    {
+        // Arrange
+        $editor = User::factory()->create(['role' => UserRole::Editor]);
+        $owner  = User::factory()->create(['role' => UserRole::Editor]);
+        $page   = Page::factory()->create(['user_id' => $owner->id]);
+
+        // Act + Assert
+        $this->actingAs($editor)->get("/admin/pages/{$page->id}/edit")->assertForbidden();
+    }
+
+    public function test_viewer_cannot_view_edit_page_form(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Viewer]);
+        $page = Page::factory()->create();
+
+        // Act + Assert
+        $this->actingAs($user)->get("/admin/pages/{$page->id}/edit")->assertForbidden();
+    }
+
+    // ─── update ───────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_update_any_page(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $page = Page::factory()->create(['title' => 'Old Title']);
+
+        // Act
+        $this->actingAs($user)->put("/admin/pages/{$page->id}", [
+            'title'   => 'New Title',
+            'content' => 'Body',
+            'status'  => 'draft',
+        ]);
+
+        // Assert
+        $this->assertDatabaseHas('pages', ['id' => $page->id, 'title' => 'New Title']);
+    }
+
+    public function test_editor_can_update_own_page(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Editor]);
+        $page = Page::factory()->create(['user_id' => $user->id]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->put("/admin/pages/{$page->id}", [
+                'title'   => 'Updated',
+                'content' => 'Body',
+                'status'  => 'draft',
+            ])
+            ->assertRedirect('/admin/pages');
+    }
+
+    public function test_editor_cannot_update_other_users_page(): void
+    {
+        // Arrange
+        $editor = User::factory()->create(['role' => UserRole::Editor]);
+        $owner  = User::factory()->create(['role' => UserRole::Editor]);
+        $page   = Page::factory()->create(['user_id' => $owner->id]);
+
+        // Act + Assert
+        $this->actingAs($editor)
+            ->put("/admin/pages/{$page->id}", [
+                'title'   => 'Hack',
+                'content' => 'Body',
+                'status'  => 'draft',
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_update_ignores_own_slug_in_uniqueness_check(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $page = Page::factory()->create(['slug' => 'my-page']);
+
+        // Act + Assert — submitting the page's own slug should not fail validation
+        $this->actingAs($user)
+            ->put("/admin/pages/{$page->id}", [
+                'title'   => 'Updated Title',
+                'slug'    => 'my-page',
+                'content' => 'Body',
+                'status'  => 'draft',
+            ])
+            ->assertRedirect('/admin/pages');
+    }
+
+    public function test_update_does_not_reset_published_at_if_already_set(): void
+    {
+        // Arrange
+        $user        = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $publishedAt = now()->subDay();
+        $page        = Page::factory()->create([
+            'status'       => ContentStatus::Published,
+            'published_at' => $publishedAt,
+        ]);
+
+        // Act
+        $this->actingAs($user)->put("/admin/pages/{$page->id}", [
+            'title'   => 'Re-published',
+            'content' => 'Body',
+            'status'  => 'published',
+        ]);
+
+        // Assert — published_at should remain unchanged
+        $this->assertDatabaseHas('pages', [
+            'id'           => $page->id,
+            'published_at' => $publishedAt->toDateTimeString(),
+        ]);
+    }
+
+    public function test_update_sets_published_at_on_first_publish(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $page = Page::factory()->create(['status' => ContentStatus::Draft, 'published_at' => null]);
+
+        // Act
+        $this->actingAs($user)->put("/admin/pages/{$page->id}", [
+            'title'   => 'Going Live',
+            'content' => 'Body',
+            'status'  => 'published',
+        ]);
+
+        // Assert
+        $this->assertNotNull($page->fresh()->published_at);
+    }
+
+    // ─── destroy ──────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_delete_any_page(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $page = Page::factory()->create();
+
+        // Act
+        $this->actingAs($user)->delete("/admin/pages/{$page->id}");
+
+        // Assert
+        $this->assertSoftDeleted('pages', ['id' => $page->id]);
+    }
+
+    public function test_editor_can_delete_own_page(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Editor]);
+        $page = Page::factory()->create(['user_id' => $user->id]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->delete("/admin/pages/{$page->id}")
+            ->assertRedirect('/admin/pages');
+
+        $this->assertSoftDeleted('pages', ['id' => $page->id]);
+    }
+
+    public function test_editor_cannot_delete_other_users_page(): void
+    {
+        // Arrange
+        $editor = User::factory()->create(['role' => UserRole::Editor]);
+        $owner  = User::factory()->create(['role' => UserRole::Editor]);
+        $page   = Page::factory()->create(['user_id' => $owner->id]);
+
+        // Act + Assert
+        $this->actingAs($editor)->delete("/admin/pages/{$page->id}")->assertForbidden();
+    }
+
+    public function test_viewer_cannot_delete_page(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Viewer]);
+        $page = Page::factory()->create();
+
+        // Act + Assert
+        $this->actingAs($user)->delete("/admin/pages/{$page->id}")->assertForbidden();
+    }
+}

--- a/laravel/tests/Feature/Admin/PostControllerTest.php
+++ b/laravel/tests/Feature/Admin/PostControllerTest.php
@@ -1,0 +1,377 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\ContentStatus;
+use App\Enums\UserRole;
+use App\Models\Category;
+use App\Models\Post;
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PostControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ─── index ───────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_view_posts_index(): void
+    {
+        // Arrange
+        $this->withoutVite();
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->get('/admin/posts')
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page->component('Admin/Posts/Index'));
+    }
+
+    public function test_viewer_can_view_posts_index(): void
+    {
+        // Arrange
+        $this->withoutVite();
+        $user = User::factory()->create(['role' => UserRole::Viewer]);
+
+        // Act + Assert
+        $this->actingAs($user)->get('/admin/posts')->assertOk();
+    }
+
+    public function test_guest_is_redirected_from_posts_index(): void
+    {
+        // Act + Assert
+        $this->get('/admin/posts')->assertRedirect(route('admin.login'));
+    }
+
+    public function test_posts_index_eager_loads_relationships(): void
+    {
+        // Arrange
+        $this->withoutVite();
+        $user     = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $category = Category::factory()->create();
+        $post     = Post::factory()->create(['category_id' => $category->id, 'user_id' => $user->id]);
+        $tag      = Tag::factory()->create();
+        $post->tags()->attach($tag);
+
+        // Act + Assert — would throw LazyLoadingViolationException if not eager-loaded
+        $this->actingAs($user)->get('/admin/posts')->assertOk();
+    }
+
+    // ─── store ────────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_create_post(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act
+        $response = $this->actingAs($user)->post('/admin/posts', [
+            'title'   => 'My Test Post',
+            'content' => 'Post content here',
+            'status'  => 'draft',
+        ]);
+
+        // Assert
+        $response->assertRedirect('/admin/posts');
+        $this->assertDatabaseHas('posts', [
+            'title'   => 'My Test Post',
+            'slug'    => 'my-test-post',
+            'user_id' => $user->id,
+        ]);
+    }
+
+    public function test_editor_can_create_post(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Editor]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/posts', [
+                'title'   => 'Editor Post',
+                'content' => 'Content',
+                'status'  => 'draft',
+            ])
+            ->assertRedirect('/admin/posts');
+    }
+
+    public function test_viewer_cannot_create_post(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Viewer]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/posts', [
+                'title'   => 'Viewer Post',
+                'content' => 'Content',
+                'status'  => 'draft',
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_store_generates_slug_from_title(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act
+        $this->actingAs($user)->post('/admin/posts', [
+            'title'   => 'Hello World Post',
+            'content' => 'Body',
+            'status'  => 'draft',
+        ]);
+
+        // Assert
+        $this->assertDatabaseHas('posts', ['slug' => 'hello-world-post']);
+    }
+
+    public function test_store_syncs_tags(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $tag1 = Tag::factory()->create();
+        $tag2 = Tag::factory()->create();
+
+        // Act
+        $this->actingAs($user)->post('/admin/posts', [
+            'title'   => 'Tagged Post',
+            'content' => 'Body',
+            'status'  => 'draft',
+            'tag_ids' => [$tag1->id, $tag2->id],
+        ]);
+
+        // Assert
+        $post = Post::first();
+        $this->assertCount(2, $post->tags);
+        $this->assertTrue($post->tags->contains($tag1));
+        $this->assertTrue($post->tags->contains($tag2));
+    }
+
+    public function test_store_with_no_tags_results_in_empty_pivot(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act
+        $this->actingAs($user)->post('/admin/posts', [
+            'title'   => 'Untagged Post',
+            'content' => 'Body',
+            'status'  => 'draft',
+        ]);
+
+        // Assert
+        $this->assertCount(0, Post::first()->tags);
+    }
+
+    public function test_store_sets_published_at_when_status_is_published(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act
+        $this->actingAs($user)->post('/admin/posts', [
+            'title'   => 'Live Post',
+            'content' => 'Content',
+            'status'  => 'published',
+        ]);
+
+        // Assert
+        $this->assertNotNull(Post::first()->published_at);
+    }
+
+    public function test_store_validates_category_exists(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/posts', [
+                'title'       => 'Post',
+                'content'     => 'Body',
+                'status'      => 'draft',
+                'category_id' => 99999,
+            ])
+            ->assertSessionHasErrors('category_id');
+    }
+
+    public function test_store_validates_tag_ids_exist(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/posts', [
+                'title'   => 'Post',
+                'content' => 'Body',
+                'status'  => 'draft',
+                'tag_ids' => [99999],
+            ])
+            ->assertSessionHasErrors('tag_ids.0');
+    }
+
+    // ─── update ───────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_update_any_post(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $post = Post::factory()->create(['title' => 'Old Title']);
+
+        // Act
+        $this->actingAs($user)->put("/admin/posts/{$post->id}", [
+            'title'   => 'New Title',
+            'content' => 'Body',
+            'status'  => 'draft',
+        ]);
+
+        // Assert
+        $this->assertDatabaseHas('posts', ['id' => $post->id, 'title' => 'New Title']);
+    }
+
+    public function test_editor_can_update_own_post(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Editor]);
+        $post = Post::factory()->create(['user_id' => $user->id]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->put("/admin/posts/{$post->id}", [
+                'title'   => 'Updated',
+                'content' => 'Body',
+                'status'  => 'draft',
+            ])
+            ->assertRedirect('/admin/posts');
+    }
+
+    public function test_editor_cannot_update_other_users_post(): void
+    {
+        // Arrange
+        $editor = User::factory()->create(['role' => UserRole::Editor]);
+        $owner  = User::factory()->create(['role' => UserRole::Editor]);
+        $post   = Post::factory()->create(['user_id' => $owner->id]);
+
+        // Act + Assert
+        $this->actingAs($editor)
+            ->put("/admin/posts/{$post->id}", [
+                'title'   => 'Hack',
+                'content' => 'Body',
+                'status'  => 'draft',
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_update_syncs_tags_replacing_previous_tags(): void
+    {
+        // Arrange
+        $user     = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $oldTag   = Tag::factory()->create();
+        $newTag   = Tag::factory()->create();
+        $post     = Post::factory()->create(['user_id' => $user->id]);
+        $post->tags()->attach($oldTag);
+
+        // Act
+        $this->actingAs($user)->put("/admin/posts/{$post->id}", [
+            'title'   => 'Updated',
+            'content' => 'Body',
+            'status'  => 'draft',
+            'tag_ids' => [$newTag->id],
+        ]);
+
+        // Assert
+        $post->refresh();
+        $this->assertCount(1, $post->tags);
+        $this->assertTrue($post->tags->contains($newTag));
+        $this->assertFalse($post->tags->contains($oldTag));
+    }
+
+    public function test_update_with_empty_tag_ids_detaches_all_tags(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $tag  = Tag::factory()->create();
+        $post = Post::factory()->create(['user_id' => $user->id]);
+        $post->tags()->attach($tag);
+
+        // Act
+        $this->actingAs($user)->put("/admin/posts/{$post->id}", [
+            'title'   => 'Updated',
+            'content' => 'Body',
+            'status'  => 'draft',
+            'tag_ids' => [],
+        ]);
+
+        // Assert
+        $this->assertCount(0, $post->fresh()->tags);
+    }
+
+    public function test_update_does_not_reset_published_at(): void
+    {
+        // Arrange
+        $user        = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $publishedAt = now()->subDay();
+        $post        = Post::factory()->create([
+            'status'       => ContentStatus::Published,
+            'published_at' => $publishedAt,
+        ]);
+
+        // Act
+        $this->actingAs($user)->put("/admin/posts/{$post->id}", [
+            'title'   => 'Re-save',
+            'content' => 'Body',
+            'status'  => 'published',
+        ]);
+
+        // Assert
+        $this->assertDatabaseHas('posts', [
+            'id'           => $post->id,
+            'published_at' => $publishedAt->toDateTimeString(),
+        ]);
+    }
+
+    // ─── destroy ──────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_delete_any_post(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $post = Post::factory()->create();
+
+        // Act
+        $this->actingAs($user)->delete("/admin/posts/{$post->id}");
+
+        // Assert
+        $this->assertSoftDeleted('posts', ['id' => $post->id]);
+    }
+
+    public function test_editor_can_delete_own_post(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Editor]);
+        $post = Post::factory()->create(['user_id' => $user->id]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->delete("/admin/posts/{$post->id}")
+            ->assertRedirect('/admin/posts');
+
+        $this->assertSoftDeleted('posts', ['id' => $post->id]);
+    }
+
+    public function test_editor_cannot_delete_other_users_post(): void
+    {
+        // Arrange
+        $editor = User::factory()->create(['role' => UserRole::Editor]);
+        $owner  = User::factory()->create(['role' => UserRole::Editor]);
+        $post   = Post::factory()->create(['user_id' => $owner->id]);
+
+        // Act + Assert
+        $this->actingAs($editor)->delete("/admin/posts/{$post->id}")->assertForbidden();
+    }
+}

--- a/laravel/tests/Feature/Admin/TagControllerTest.php
+++ b/laravel/tests/Feature/Admin/TagControllerTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\UserRole;
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TagControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ─── index ───────────────────────────────────────────────────────────────
+
+    public function test_all_roles_can_view_tags_index(): void
+    {
+        // Arrange
+        $this->withoutVite();
+
+        foreach ([UserRole::SuperAdmin, UserRole::Editor, UserRole::Viewer] as $role) {
+            $user = User::factory()->create(['role' => $role]);
+
+            // Act + Assert
+            $this->actingAs($user)->get('/admin/tags')->assertOk();
+        }
+    }
+
+    public function test_guest_is_redirected_from_tags_index(): void
+    {
+        // Act + Assert
+        $this->get('/admin/tags')->assertRedirect(route('admin.login'));
+    }
+
+    // ─── store ────────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_create_tag(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act
+        $response = $this->actingAs($user)->post('/admin/tags', ['name' => 'Laravel']);
+
+        // Assert
+        $response->assertRedirect('/admin/tags');
+        $this->assertDatabaseHas('tags', ['name' => 'Laravel', 'slug' => 'laravel']);
+    }
+
+    public function test_editor_can_create_tag(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Editor]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/tags', ['name' => 'Vue'])
+            ->assertRedirect('/admin/tags');
+    }
+
+    public function test_viewer_cannot_create_tag(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Viewer]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/tags', ['name' => 'Hacked'])
+            ->assertForbidden();
+    }
+
+    public function test_store_generates_slug_from_name(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act
+        $this->actingAs($user)->post('/admin/tags', ['name' => 'Open Source']);
+
+        // Assert
+        $this->assertDatabaseHas('tags', ['slug' => 'open-source']);
+    }
+
+    public function test_store_rejects_duplicate_slug(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        Tag::factory()->create(['slug' => 'php']);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/tags', ['name' => 'Anything', 'slug' => 'php'])
+            ->assertSessionHasErrors('slug');
+    }
+
+    // ─── update ───────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_update_tag(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $tag  = Tag::factory()->create(['name' => 'Old']);
+
+        // Act
+        $this->actingAs($user)->put("/admin/tags/{$tag->id}", ['name' => 'New']);
+
+        // Assert
+        $this->assertDatabaseHas('tags', ['id' => $tag->id, 'name' => 'New']);
+    }
+
+    public function test_editor_can_update_tag(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Editor]);
+        $tag  = Tag::factory()->create();
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->put("/admin/tags/{$tag->id}", ['name' => 'Updated'])
+            ->assertRedirect('/admin/tags');
+    }
+
+    public function test_viewer_cannot_update_tag(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Viewer]);
+        $tag  = Tag::factory()->create();
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->put("/admin/tags/{$tag->id}", ['name' => 'Hacked'])
+            ->assertForbidden();
+    }
+
+    public function test_update_ignores_own_slug(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $tag  = Tag::factory()->create(['slug' => 'my-tag']);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->put("/admin/tags/{$tag->id}", ['name' => 'My Tag', 'slug' => 'my-tag'])
+            ->assertRedirect('/admin/tags');
+    }
+
+    // ─── destroy ──────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_delete_tag(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $tag  = Tag::factory()->create();
+
+        // Act
+        $this->actingAs($user)->delete("/admin/tags/{$tag->id}");
+
+        // Assert
+        $this->assertDatabaseMissing('tags', ['id' => $tag->id]);
+    }
+
+    public function test_editor_can_delete_tag(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Editor]);
+        $tag  = Tag::factory()->create();
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->delete("/admin/tags/{$tag->id}")
+            ->assertRedirect('/admin/tags');
+    }
+
+    public function test_viewer_cannot_delete_tag(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Viewer]);
+        $tag  = Tag::factory()->create();
+
+        // Act + Assert
+        $this->actingAs($user)->delete("/admin/tags/{$tag->id}")->assertForbidden();
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -70,9 +70,9 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 | Status | # | Issue | Labels |
 |--------|---|-------|--------|
 | ⬜ | [#2](https://github.com/Three-Hoops/Hoops-CMS/issues/2) | Phase 2: Core Content (Pages, Posts, Categories, Tags) — umbrella | `content`, `enhancement` |
-| ⬜ | [#156](https://github.com/Three-Hoops/Hoops-CMS/issues/156) | Create content migrations (categories, tags, pages, posts, post_tag) | `content`, `enhancement` |
-| ⬜ | [#157](https://github.com/Three-Hoops/Hoops-CMS/issues/157) | Add ContentStatus enum and content models (Category, Tag, Page, Post) | `content`, `enhancement` |
-| ⬜ | [#158](https://github.com/Three-Hoops/Hoops-CMS/issues/158) | Add controllers, form requests, and policies for content types | `content`, `enhancement` |
+| ✅ | [#156](https://github.com/Three-Hoops/Hoops-CMS/issues/156) | Create content migrations (categories, tags, pages, posts, post_tag) | `content`, `enhancement` |
+| ✅ | [#157](https://github.com/Three-Hoops/Hoops-CMS/issues/157) | Add ContentStatus enum and content models (Category, Tag, Page, Post) | `content`, `enhancement` |
+| ✅ | [#158](https://github.com/Three-Hoops/Hoops-CMS/issues/158) | Add controllers, form requests, and policies for content types | `content`, `enhancement` |
 | ⬜ | [#159](https://github.com/Three-Hoops/Hoops-CMS/issues/159) | Register admin resource routes for content types | `content`, `enhancement` |
 | ⬜ | [#160](https://github.com/Three-Hoops/Hoops-CMS/issues/160) | Build Vue pages and shared components for content management | `content`, `enhancement` |
 | ⬜ | [#76](https://github.com/Three-Hoops/Hoops-CMS/issues/76) | Add parent_id to pages table for hierarchical page structure | `content`, `enhancement` |


### PR DESCRIPTION
Closes #158

## Summary

- Added `AuthorizesRequests` trait to the base `Controller` so `$this->authorize()` works across all admin controllers
- Created 4 Laravel policies (`PagePolicy`, `PostPolicy`, `CategoryPolicy`, `TagPolicy`) — auto-discovered by Laravel convention, no `AuthServiceProvider` needed
- Created 8 form requests (`StorePage`, `UpdatePage`, `StorePost`, `UpdatePost`, `StoreCategory`, `UpdateCategory`, `StoreTag`, `UpdateTag`) with slug uniqueness (`Rule::unique()->ignore()`), `Rule::enum(ContentStatus::class)` validation, and policy-based authorization
- Created 4 admin controllers (`PageController`, `PostController`, `CategoryController`, `TagController`) with full CRUD (no `show`), slug auto-generation, `published_at` first-publish logic, tag sync via `Arr::pull` + `sync()`, and explicit eager-loading throughout (required by `Model::preventLazyLoading()`)
- Updated `DashboardController` to return real stats (post/page counts by status, category/tag counts, 5 most recent posts)
- Added 5 feature test files covering all authorization scenarios (SuperAdmin / Editor-own / Editor-other / Viewer), slug generation, `published_at` logic, tag sync, and dashboard stat correctness

## Test plan

- [ ] `php artisan test --filter PageController` — all ownership + CRUD tests green (requires routes from #159)
- [ ] `php artisan test --filter PostController` — including tag sync tests
- [ ] `php artisan test --filter CategoryController` — including self-parent rejection
- [ ] `php artisan test --filter TagController`
- [ ] `php artisan test --filter DashboardStats` — counts + soft-delete exclusion

> **Note:** Controller tests use hardcoded REST paths (e.g. `POST /admin/pages`) that will be registered in #159. Tests will be fully green once #159 routes are in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)