### PR TITLE
Add parent_id to pages for hierarchical page structure

### DIFF
--- a/laravel/app/Http/Controllers/Admin/PageController.php
+++ b/laravel/app/Http/Controllers/Admin/PageController.php
@@ -19,7 +19,7 @@ class PageController extends Controller
     {
         $this->authorize('viewAny', Page::class);
 
-        $pages = Page::with('author')
+        $pages = Page::with(['author', 'parent'])
             ->latest()
             ->paginate(15);
 
@@ -32,7 +32,9 @@ class PageController extends Controller
     {
         $this->authorize('create', Page::class);
 
-        return Inertia::render('Admin/Pages/Create');
+        return Inertia::render('Admin/Pages/Create', [
+            'pages' => Page::select('id', 'title', 'slug')->orderBy('title')->get(),
+        ]);
     }
 
     public function store(StorePage $request): RedirectResponse
@@ -58,7 +60,8 @@ class PageController extends Controller
         $this->authorize('update', $page);
 
         return Inertia::render('Admin/Pages/Edit', [
-            'page' => $page->load('author'),
+            'page' => $page->load(['author', 'parent']),
+            'pages' => Page::select('id', 'title', 'slug')->where('id', '!=', $page->id)->orderBy('title')->get(),
         ]);
     }
 

--- a/laravel/app/Http/Requests/Admin/StorePage.php
+++ b/laravel/app/Http/Requests/Admin/StorePage.php
@@ -27,6 +27,7 @@ class StorePage extends FormRequest
             'meta_description' => ['nullable', 'string', 'max:255'],
             'meta_keywords'    => ['nullable', 'string', 'max:255'],
             'published_at'     => ['nullable', 'date'],
+            'parent_id'        => ['nullable', 'integer', Rule::exists('pages', 'id')],
         ];
     }
 }

--- a/laravel/app/Http/Requests/Admin/UpdatePage.php
+++ b/laravel/app/Http/Requests/Admin/UpdatePage.php
@@ -5,6 +5,8 @@ namespace App\Http\Requests\Admin;
 use App\Enums\ContentStatus;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Closure;
+use App\Models\Page;
 
 class UpdatePage extends FormRequest
 {
@@ -28,6 +30,20 @@ class UpdatePage extends FormRequest
             'meta_description' => ['nullable', 'string', 'max:255'],
             'meta_keywords'    => ['nullable', 'string', 'max:255'],
             'published_at'     => ['nullable', 'date'],
+            'parent_id'        => ['nullable', 'integer', Rule::exists('pages', 'id'), function (string $attribute, mixed $value, Closure $fail) {
+                $page = $this->route('page');
+                if ($value === null) {
+                    return;
+                }
+                if ((int) $value === $page->id) {
+                    $fail('A page cannot be its own parent.');
+                    return;
+                }
+                $candidate = Page::find($value);
+                if ($candidate && $candidate->isDescendantOf($page)) {
+                    $fail('A page cannot be assigned a descendant as its parent.');
+                }
+            }]
         ];
     }
 }

--- a/laravel/app/Models/Page.php
+++ b/laravel/app/Models/Page.php
@@ -11,10 +11,11 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  */
-#[Fillable(['title', 'slug', 'content', 'content_json', 'excerpt', 'status', 'meta_title', 'meta_description', 'meta_keywords', 'user_id', 'published_at'])]
+#[Fillable(['title', 'slug', 'content', 'content_json', 'excerpt', 'status', 'meta_title', 'meta_description', 'meta_keywords', 'user_id', 'published_at', 'parent_id'])]
 class Page extends Model
 {
     /** @use HasFactory<PageFactory> */
@@ -42,5 +43,28 @@ class Page extends Model
     public function scopePublished(Builder $query): void
     {
         $query->where('status', ContentStatus::Published);
+    }
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(Page::class, 'parent_id');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(Page::class, 'parent_id');
+    }
+
+    //prevent circular references
+    public function isDescendantOf(Page $page): bool {
+        $current = $this->parent;
+        while($current !== null) {
+            if($current->id === $page->id) {
+                return true;
+            }
+            $current = $current->parent;
+        }
+
+        return false;
     }
 }

--- a/laravel/database/migrations/2026_04_20_092426_create_pages_table.php
+++ b/laravel/database/migrations/2026_04_20_092426_create_pages_table.php
@@ -29,6 +29,8 @@ return new class extends Migration
             $table->softDeletes();
             $table->index('status');
             $table->index('published_at');
+            $table->foreignId('parent_id')->nullable()->constrained('pages')->nullOnDelete();
+            $table->index('parent_id');
         });
     }
 

--- a/laravel/resources/js/Pages/Admin/Pages/Create.vue
+++ b/laravel/resources/js/Pages/Admin/Pages/Create.vue
@@ -78,16 +78,16 @@ function submit() {
       <div class="space-y-2">
         <Label>Parent Page</Label>
         <Select
-          :model-value="form.parent_id?.toString() ?? ''"
+          :model-value="form.parent_id != null ? form.parent_id.toString() : 'none'"
           @update:model-value="
-            (val) => (form.parent_id = val ? Number(val) : null)
+            (val) => (form.parent_id = val === 'none' ? null : Number(val))
           "
         >
           <SelectTrigger>
             <SelectValue placeholder="None (top-level)" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="">
+            <SelectItem value="none">
               None (top-level)
             </SelectItem>
             <SelectItem

--- a/laravel/resources/js/Pages/Admin/Pages/Create.vue
+++ b/laravel/resources/js/Pages/Admin/Pages/Create.vue
@@ -1,27 +1,38 @@
 <script setup lang="ts">
-import { useForm, Link } from '@inertiajs/vue3'
-import { route } from 'ziggy-js'
-import AdminLayout from '@/Layouts/AdminLayout.vue'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { Textarea } from '@/components/ui/textarea'
-import TipTapEditor from '@/components/Admin/TipTapEditor.vue'
-import SlugInput from '@/components/Admin/SlugInput.vue'
+import { useForm, Link } from "@inertiajs/vue3";
+import { route } from "ziggy-js";
+import AdminLayout from "@/Layouts/AdminLayout.vue";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import TipTapEditor from "@/components/Admin/TipTapEditor.vue";
+import SlugInput from "@/components/Admin/SlugInput.vue";
+
+defineProps<{
+    pages: Array<{ id: number; title: string; slug: string }>;
+}>();
 
 const form = useForm({
-    title: '',
-    slug: '',
-    content: '',
-    status: 'draft' as 'draft' | 'published',
-    meta_title: '',
-    meta_description: '',
-    published_at: '',
-})
+    title: "",
+    slug: "",
+    content: "",
+    status: "draft" as "draft" | "published",
+    meta_title: "",
+    meta_description: "",
+    published_at: "",
+    parent_id: null as number | null,
+});
 
 function submit() {
-    form.post(route('admin.pages.store'))
+    form.post(route("admin.pages.store"));
 }
 </script>
 
@@ -62,6 +73,32 @@ function submit() {
         >
           {{ form.errors.slug }}
         </p>
+      </div>
+
+      <div class="space-y-2">
+        <Label>Parent Page</Label>
+        <Select
+          :model-value="form.parent_id?.toString() ?? ''"
+          @update:model-value="
+            (val) => (form.parent_id = val ? Number(val) : null)
+          "
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="None (top-level)" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="">
+              None (top-level)
+            </SelectItem>
+            <SelectItem
+              v-for="p in pages"
+              :key="p.id"
+              :value="p.id.toString()"
+            >
+              {{ p.title }}
+            </SelectItem>
+          </SelectContent>
+        </Select>
       </div>
 
       <div class="space-y-2">

--- a/laravel/resources/js/Pages/Admin/Pages/Edit.vue
+++ b/laravel/resources/js/Pages/Admin/Pages/Edit.vue
@@ -1,34 +1,42 @@
 <script setup lang="ts">
-import { useForm, Link } from '@inertiajs/vue3'
-import { route } from 'ziggy-js'
-import AdminLayout from '@/Layouts/AdminLayout.vue'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { Textarea } from '@/components/ui/textarea'
-import TipTapEditor from '@/components/Admin/TipTapEditor.vue'
-import SlugInput from '@/components/Admin/SlugInput.vue'
-import type { Page } from '@/types/models'
+import { useForm, Link } from "@inertiajs/vue3";
+import { route } from "ziggy-js";
+import AdminLayout from "@/Layouts/AdminLayout.vue";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import TipTapEditor from "@/components/Admin/TipTapEditor.vue";
+import SlugInput from "@/components/Admin/SlugInput.vue";
+import type { Page } from "@/types/models";
 
 const props = defineProps<{
-    page: Page
-}>()
+    page: Page;
+    pages: Array<{ id: number; title: string; slug: string }>;
+}>();
 
 const form = useForm({
     title: props.page.title,
     slug: props.page.slug,
     content: props.page.content,
     status: props.page.status,
-    meta_title: props.page.meta_title ?? '',
-    meta_description: props.page.meta_description ?? '',
+    meta_title: props.page.meta_title ?? "",
+    meta_description: props.page.meta_description ?? "",
     published_at: props.page.published_at
-        ? props.page.published_at.replace(' ', 'T').slice(0, 16)
-        : '',
-})
+        ? props.page.published_at.replace(" ", "T").slice(0, 16)
+        : "",
+    parent_id: props.page.parent_id,
+});
 
 function submit() {
-    form.put(route('admin.pages.update', props.page.id))
+    form.put(route("admin.pages.update", props.page.id));
 }
 </script>
 
@@ -66,6 +74,32 @@ function submit() {
         >
           {{ form.errors.slug }}
         </p>
+      </div>
+
+      <div class="space-y-2">
+        <Label>Parent Page</Label>
+        <Select
+          :model-value="form.parent_id?.toString() ?? ''"
+          @update:model-value="
+            (val) => (form.parent_id = val ? Number(val) : null)
+          "
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="None (top-level)" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="">
+              None (top-level)
+            </SelectItem>
+            <SelectItem
+              v-for="p in pages"
+              :key="p.id"
+              :value="p.id.toString()"
+            >
+              {{ p.title }}
+            </SelectItem>
+          </SelectContent>
+        </Select>
       </div>
 
       <div class="space-y-2">

--- a/laravel/resources/js/Pages/Admin/Pages/Edit.vue
+++ b/laravel/resources/js/Pages/Admin/Pages/Edit.vue
@@ -79,16 +79,16 @@ function submit() {
       <div class="space-y-2">
         <Label>Parent Page</Label>
         <Select
-          :model-value="form.parent_id?.toString() ?? ''"
+          :model-value="form.parent_id != null ? form.parent_id.toString() : 'none'"
           @update:model-value="
-            (val) => (form.parent_id = val ? Number(val) : null)
+            (val) => (form.parent_id = val === 'none' ? null : Number(val))
           "
         >
           <SelectTrigger>
             <SelectValue placeholder="None (top-level)" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="">
+            <SelectItem value="none">
               None (top-level)
             </SelectItem>
             <SelectItem

--- a/laravel/resources/js/Pages/Admin/Pages/Index.vue
+++ b/laravel/resources/js/Pages/Admin/Pages/Index.vue
@@ -1,29 +1,31 @@
 <script setup lang="ts">
-import { ref } from 'vue'
-import { Link, router } from '@inertiajs/vue3'
-import { route } from 'ziggy-js'
-import AdminLayout from '@/Layouts/AdminLayout.vue'
-import { Button } from '@/components/ui/button'
-import StatusBadge from '@/components/Admin/StatusBadge.vue'
-import Pagination from '@/components/Admin/Pagination.vue'
-import ConfirmModal from '@/components/Admin/ConfirmModal.vue'
-import type { Page, Paginated } from '@/types/models'
+import { ref } from "vue";
+import { Link, router } from "@inertiajs/vue3";
+import { route } from "ziggy-js";
+import AdminLayout from "@/Layouts/AdminLayout.vue";
+import { Button } from "@/components/ui/button";
+import StatusBadge from "@/components/Admin/StatusBadge.vue";
+import Pagination from "@/components/Admin/Pagination.vue";
+import ConfirmModal from "@/components/Admin/ConfirmModal.vue";
+import type { Page, Paginated } from "@/types/models";
 
 defineProps<{
-    pages: Paginated<Page>
-}>()
+    pages: Paginated<Page>;
+}>();
 
-const deletingId = ref<number | null>(null)
+const deletingId = ref<number | null>(null);
 
 function confirmDelete(id: number) {
-    deletingId.value = id
+    deletingId.value = id;
 }
 
 function doDelete() {
-    if (deletingId.value === null) return
-    router.delete(route('admin.pages.destroy', deletingId.value), {
-        onFinish: () => { deletingId.value = null },
-    })
+    if (deletingId.value === null) return;
+    router.delete(route("admin.pages.destroy", deletingId.value), {
+        onFinish: () => {
+            deletingId.value = null;
+        },
+    });
 }
 </script>
 
@@ -53,6 +55,9 @@ function doDelete() {
                 Slug
               </th>
               <th class="px-4 py-3 font-medium">
+                Parent
+              </th>
+              <th class="px-4 py-3 font-medium">
                 Status
               </th>
               <th class="px-4 py-3 font-medium">
@@ -64,11 +69,9 @@ function doDelete() {
             </tr>
           </thead>
           <tbody>
-            <tr
-              v-if="pages.data.length === 0"
-            >
+            <tr v-if="pages.data.length === 0">
               <td
-                colspan="5"
+                colspan="6"
                 class="px-4 py-8 text-center text-muted-foreground"
               >
                 No pages yet.
@@ -85,11 +88,20 @@ function doDelete() {
               <td class="px-4 py-3 text-muted-foreground">
                 {{ page.slug }}
               </td>
+              <td class="px-4 py-3 text-muted-foreground">
+                {{ page.parent ? page.parent.title : "—" }}
+              </td>
               <td class="px-4 py-3">
                 <StatusBadge :status="page.status" />
               </td>
               <td class="px-4 py-3 text-muted-foreground">
-                {{ page.published_at ? new Date(page.published_at).toLocaleDateString() : '—' }}
+                {{
+                  page.published_at
+                    ? new Date(
+                      page.published_at
+                    ).toLocaleDateString()
+                    : "—"
+                }}
               </td>
               <td class="px-4 py-3">
                 <div class="flex items-center gap-2">
@@ -98,7 +110,14 @@ function doDelete() {
                     size="sm"
                     as-child
                   >
-                    <Link :href="route('admin.pages.edit', page.id)">
+                    <Link
+                      :href="
+                        route(
+                          'admin.pages.edit',
+                          page.id
+                        )
+                      "
+                    >
                       Edit
                     </Link>
                   </Button>

--- a/laravel/resources/js/tests/Pages/Admin/Pages/Create.test.ts
+++ b/laravel/resources/js/tests/Pages/Admin/Pages/Create.test.ts
@@ -5,7 +5,7 @@ import PagesCreate from '@/Pages/Admin/Pages/Create.vue'
 const { mockPost, mockUseForm } = vi.hoisted(() => {
     const post = vi.fn()
     const useForm = vi.fn(() => ({
-        title: '', slug: '', content: '', status: 'draft', meta_title: '', meta_description: '', published_at: '', parent_id: null,
+        title: '', slug: '', content: '', status: 'draft', meta_title: '', meta_description: '', published_at: '', parent_id: null as number | null,
         processing: false, errors: {} as Record<string, string>, post,
     }))
     return { mockPost: post, mockUseForm: useForm }

--- a/laravel/resources/js/tests/Pages/Admin/Pages/Create.test.ts
+++ b/laravel/resources/js/tests/Pages/Admin/Pages/Create.test.ts
@@ -5,7 +5,7 @@ import PagesCreate from '@/Pages/Admin/Pages/Create.vue'
 const { mockPost, mockUseForm } = vi.hoisted(() => {
     const post = vi.fn()
     const useForm = vi.fn(() => ({
-        title: '', slug: '', content: '', status: 'draft', meta_title: '', meta_description: '', published_at: '',
+        title: '', slug: '', content: '', status: 'draft', meta_title: '', meta_description: '', published_at: '', parent_id: null,
         processing: false, errors: {} as Record<string, string>, post,
     }))
     return { mockPost: post, mockUseForm: useForm }
@@ -55,13 +55,15 @@ const globalConfig = {
 }
 
 describe('Pages/Create', () => {
+const pages = [{ id: 1, title: 'Home', slug: 'home' }]
+
     it('renders the page title "New Page"', () => {
-        const wrapper = mount(PagesCreate, globalConfig)
+        const wrapper = mount(PagesCreate, { props: { pages }, ...globalConfig })
         expect(wrapper.text()).toContain('New Page')
     })
 
     it('renders title, slug, status, meta fields', () => {
-        const wrapper = mount(PagesCreate, globalConfig)
+        const wrapper = mount(PagesCreate, { props: { pages }, ...globalConfig })
         expect(wrapper.text()).toContain('Title')
         expect(wrapper.text()).toContain('Slug')
         expect(wrapper.text()).toContain('Status')
@@ -70,22 +72,22 @@ describe('Pages/Create', () => {
     })
 
     it('renders the TipTap editor', () => {
-        const wrapper = mount(PagesCreate, globalConfig)
+        const wrapper = mount(PagesCreate, { props: { pages }, ...globalConfig })
         expect(wrapper.find('.tiptap').exists()).toBe(true)
     })
 
     it('calls form.post on submit', async () => {
-        const wrapper = mount(PagesCreate, globalConfig)
+        const wrapper = mount(PagesCreate, { props: { pages }, ...globalConfig })
         await wrapper.find('form').trigger('submit')
         expect(mockPost).toHaveBeenCalledWith('/admin.pages.store')
     })
 
     it('shows validation error when title error is set', () => {
         mockUseForm.mockReturnValueOnce({
-            title: '', slug: '', content: '', status: 'draft', meta_title: '', meta_description: '', published_at: '',
+            title: '', slug: '', content: '', status: 'draft', meta_title: '', meta_description: '', published_at: '', parent_id: null,
             processing: false, errors: { title: 'The title field is required.' }, post: mockPost,
         })
-        const wrapper = mount(PagesCreate, globalConfig)
+        const wrapper = mount(PagesCreate, { props: { pages }, ...globalConfig })
         expect(wrapper.text()).toContain('The title field is required.')
     })
 })

--- a/laravel/resources/js/tests/Pages/Admin/Pages/Create.test.ts
+++ b/laravel/resources/js/tests/Pages/Admin/Pages/Create.test.ts
@@ -35,6 +35,12 @@ vi.mock('@/composables/useThemeMode', () => ({
 
 vi.mock('@/components/Admin/FlashBanner.vue', () => ({ default: { template: '<div />' } }))
 
+const SelectStub = {
+    template: '<div :data-model="modelValue"><slot /></div>',
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+}
+
 const globalConfig = {
     global: {
         stubs: {
@@ -43,7 +49,7 @@ const globalConfig = {
             Input: { template: '<input :id="id" />', props: ['id', 'modelValue', 'type', 'class'] },
             Label: { template: '<label><slot /></label>', props: ['for'] },
             Textarea: { template: '<textarea />', props: ['id', 'modelValue', 'rows'] },
-            Select: { template: '<div><slot /></div>', props: ['modelValue'] },
+            Select: SelectStub,
             SelectTrigger: { template: '<div><slot /></div>' },
             SelectContent: { template: '<div><slot /></div>' },
             SelectItem: { template: '<div><slot /></div>', props: ['value'] },
@@ -89,5 +95,53 @@ const pages = [{ id: 1, title: 'Home', slug: 'home' }]
         })
         const wrapper = mount(PagesCreate, { props: { pages }, ...globalConfig })
         expect(wrapper.text()).toContain('The title field is required.')
+    })
+
+    it('passes "none" as modelValue to parent selector when parent_id is null', () => {
+        // Arrange
+        const wrapper = mount(PagesCreate, { props: { pages }, ...globalConfig })
+
+        // Act + Assert — first Select stub is the parent page selector
+        const parentSelect = wrapper.findAllComponents(SelectStub)[0]
+        expect(parentSelect.attributes('data-model')).toBe('none')
+    })
+
+    it('passes parent_id as string modelValue to parent selector when set', () => {
+        // Arrange
+        mockUseForm.mockReturnValueOnce({
+            title: '', slug: '', content: '', status: 'draft', meta_title: '', meta_description: '', published_at: '', parent_id: 1,
+            processing: false, errors: {} as Record<string, string>, post: mockPost,
+        })
+        const wrapper = mount(PagesCreate, { props: { pages }, ...globalConfig })
+
+        // Act + Assert
+        const parentSelect = wrapper.findAllComponents(SelectStub)[0]
+        expect(parentSelect.attributes('data-model')).toBe('1')
+    })
+
+    it('sets parent_id to null when "none" is selected in parent dropdown', async () => {
+        // Arrange
+        const form = { title: '', slug: '', content: '', status: 'draft', meta_title: '', meta_description: '', published_at: '', parent_id: 1 as number | null, processing: false, errors: {} as Record<string, string>, post: mockPost }
+        mockUseForm.mockReturnValueOnce(form)
+        const wrapper = mount(PagesCreate, { props: { pages }, ...globalConfig })
+
+        // Act
+        await wrapper.findAllComponents(SelectStub)[0].vm.$emit('update:modelValue', 'none')
+
+        // Assert
+        expect(form.parent_id).toBeNull()
+    })
+
+    it('sets parent_id to a number when a page is selected in parent dropdown', async () => {
+        // Arrange
+        const form = { title: '', slug: '', content: '', status: 'draft', meta_title: '', meta_description: '', published_at: '', parent_id: null as number | null, processing: false, errors: {} as Record<string, string>, post: mockPost }
+        mockUseForm.mockReturnValueOnce(form)
+        const wrapper = mount(PagesCreate, { props: { pages }, ...globalConfig })
+
+        // Act
+        await wrapper.findAllComponents(SelectStub)[0].vm.$emit('update:modelValue', '2')
+
+        // Assert
+        expect(form.parent_id).toBe(2)
     })
 })

--- a/laravel/resources/js/tests/Pages/Admin/Pages/Edit.test.ts
+++ b/laravel/resources/js/tests/Pages/Admin/Pages/Edit.test.ts
@@ -10,7 +10,10 @@ const page: Page = {
     excerpt: null, status: 'published', meta_title: 'SEO Title', meta_description: 'SEO desc',
     meta_keywords: null, published_at: '2025-03-01 09:00:00', created_at: '2025-01-01 10:00:00', updated_at: '2025-01-01 10:00:00',
     author: { id: 1, name: 'Alice', email: 'a@example.com', role: 'super_admin', locale: 'en', last_login_at: null, theme_mode: 'system', timezone: 'UTC' },
+    parent_id: null, parent: null,
 }
+
+const pages = [{ id: 1, title: 'Home', slug: 'home' }, { id: 2, title: 'About', slug: 'about' }]
 
 vi.mock('@inertiajs/vue3', () => ({
     usePage: () => ({
@@ -62,30 +65,30 @@ const globalConfig = {
 
 describe('Pages/Edit', () => {
     it('renders the page title "Edit Page"', () => {
-        const wrapper = mount(PagesEdit, { props: { page }, ...globalConfig })
+        const wrapper = mount(PagesEdit, { props: { page, pages }, ...globalConfig })
         expect(wrapper.text()).toContain('Edit Page')
     })
 
     it('pre-populates the title field', () => {
-        const wrapper = mount(PagesEdit, { props: { page }, ...globalConfig })
+        const wrapper = mount(PagesEdit, { props: { page, pages }, ...globalConfig })
         const inputs = wrapper.findAll('input')
         const titleInput = inputs.find(i => i.attributes('value') === 'My Page')
         expect(titleInput).toBeTruthy()
     })
 
     it('pre-populates the slug field', () => {
-        const wrapper = mount(PagesEdit, { props: { page }, ...globalConfig })
+        const wrapper = mount(PagesEdit, { props: { page, pages }, ...globalConfig })
         const inputs = wrapper.findAll('input')
         expect(inputs.some(i => i.attributes('value') === 'my-page')).toBe(true)
     })
 
     it('pre-populates the content in TipTap editor', () => {
-        const wrapper = mount(PagesEdit, { props: { page }, ...globalConfig })
+        const wrapper = mount(PagesEdit, { props: { page, pages }, ...globalConfig })
         expect(wrapper.find('.tiptap').attributes('data-value')).toBe('<p>Content</p>')
     })
 
     it('calls form.put on submit', async () => {
-        const wrapper = mount(PagesEdit, { props: { page }, ...globalConfig })
+        const wrapper = mount(PagesEdit, { props: { page, pages }, ...globalConfig })
         await wrapper.find('form').trigger('submit')
         expect(mockPut).toHaveBeenCalledWith('/admin.pages.update/5')
     })

--- a/laravel/resources/js/tests/Pages/Admin/Pages/Edit.test.ts
+++ b/laravel/resources/js/tests/Pages/Admin/Pages/Edit.test.ts
@@ -3,7 +3,16 @@ import { describe, it, expect, vi } from 'vitest'
 import PagesEdit from '@/Pages/Admin/Pages/Edit.vue'
 import type { Page } from '@/types/models'
 
-const { mockPut } = vi.hoisted(() => ({ mockPut: vi.fn() }))
+const { mockPut, mockUseForm } = vi.hoisted(() => {
+    const mockPut = vi.fn()
+    const mockUseForm = vi.fn((initial: Record<string, unknown>) => ({
+        ...initial,
+        processing: false,
+        errors: {},
+        put: mockPut,
+    }))
+    return { mockPut, mockUseForm }
+})
 
 const page: Page = {
     id: 5, user_id: 1, title: 'My Page', slug: 'my-page', content: '<p>Content</p>', content_json: {},
@@ -20,12 +29,7 @@ vi.mock('@inertiajs/vue3', () => ({
         url: '/admin/pages/5/edit',
         props: { app: { name: 'Hoops CMS' }, auth: null, flash: { success: null, error: null }, errors: {}, ziggy: { location: 'http://localhost', routes: {} } },
     }),
-    useForm: vi.fn((initial: Record<string, unknown>) => ({
-        ...initial,
-        processing: false,
-        errors: {},
-        put: mockPut,
-    })),
+    useForm: mockUseForm,
     Head: { template: '<div />' },
     Link: { template: '<a :href="href"><slot /></a>', props: ['href'] },
 }))
@@ -44,6 +48,12 @@ vi.mock('@/composables/useThemeMode', () => ({
 
 vi.mock('@/components/Admin/FlashBanner.vue', () => ({ default: { template: '<div />' } }))
 
+const SelectStub = {
+    template: '<div :data-model="modelValue"><slot /></div>',
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+}
+
 const globalConfig = {
     global: {
         stubs: {
@@ -52,7 +62,7 @@ const globalConfig = {
             Input: { template: '<input :id="id" :value="modelValue" />', props: ['id', 'modelValue', 'type', 'class'] },
             Label: { template: '<label><slot /></label>', props: ['for'] },
             Textarea: { template: '<textarea :value="modelValue" />', props: ['id', 'modelValue', 'rows'] },
-            Select: { template: '<div><slot /></div>', props: ['modelValue'] },
+            Select: SelectStub,
             SelectTrigger: { template: '<div><slot /></div>' },
             SelectContent: { template: '<div><slot /></div>' },
             SelectItem: { template: '<div><slot /></div>', props: ['value'] },
@@ -91,5 +101,44 @@ describe('Pages/Edit', () => {
         const wrapper = mount(PagesEdit, { props: { page, pages }, ...globalConfig })
         await wrapper.find('form').trigger('submit')
         expect(mockPut).toHaveBeenCalledWith('/admin.pages.update/5')
+    })
+
+    it('passes parent_id as string modelValue to parent selector when set', () => {
+        // Arrange
+        const pageWithParent = { ...page, parent_id: 2, parent: { id: 2, title: 'About', slug: 'about' } }
+
+        // Act
+        const wrapper = mount(PagesEdit, { props: { page: pageWithParent, pages }, ...globalConfig })
+
+        // Assert — first Select stub is the parent page selector
+        const parentSelect = wrapper.findAllComponents(SelectStub)[0]
+        expect(parentSelect.attributes('data-model')).toBe('2')
+    })
+
+    it('sets parent_id to null when "none" is selected in parent dropdown', async () => {
+        // Arrange
+        const pageWithParent = { ...page, parent_id: 2, parent: { id: 2, title: 'About', slug: 'about' } }
+        const form = { ...pageWithParent, processing: false, errors: {}, put: mockPut }
+        mockUseForm.mockReturnValueOnce(form)
+        const wrapper = mount(PagesEdit, { props: { page: pageWithParent, pages }, ...globalConfig })
+
+        // Act
+        await wrapper.findAllComponents(SelectStub)[0].vm.$emit('update:modelValue', 'none')
+
+        // Assert
+        expect(form.parent_id).toBeNull()
+    })
+
+    it('sets parent_id to a number when a page is selected in parent dropdown', async () => {
+        // Arrange
+        const form = { ...page, processing: false, errors: {}, put: mockPut }
+        mockUseForm.mockReturnValueOnce(form)
+        const wrapper = mount(PagesEdit, { props: { page, pages }, ...globalConfig })
+
+        // Act
+        await wrapper.findAllComponents(SelectStub)[0].vm.$emit('update:modelValue', '1')
+
+        // Assert
+        expect(form.parent_id).toBe(1)
     })
 })

--- a/laravel/resources/js/tests/Pages/Admin/Pages/Index.test.ts
+++ b/laravel/resources/js/tests/Pages/Admin/Pages/Index.test.ts
@@ -104,4 +104,24 @@ describe('Pages/Index', () => {
         await wrapper.findComponent({ name: 'ConfirmModal' }).vm.$emit('cancel')
         expect(wrapper.find('[data-open="true"]').exists()).toBe(false)
     })
+
+    it('shows parent title when page has a parent', () => {
+        // Arrange
+        const pageWithParent = makePage({ parent_id: 3, parent: { id: 3, title: 'Home', slug: 'home' } })
+        const withParent: Paginated<Page> = { ...pages, data: [pageWithParent] }
+
+        // Act
+        const wrapper = mount(PagesIndex, { props: { pages: withParent }, ...globalConfig })
+
+        // Assert
+        expect(wrapper.text()).toContain('Home')
+    })
+
+    it('shows em-dash in parent column when page has no parent', () => {
+        // Arrange — default pages fixture has parent: null
+        const wrapper = mount(PagesIndex, { props: { pages }, ...globalConfig })
+
+        // Assert — at least one em-dash present (published_at and parent columns)
+        expect(wrapper.text()).toContain('—')
+    })
 })

--- a/laravel/resources/js/tests/Pages/Admin/Pages/Index.test.ts
+++ b/laravel/resources/js/tests/Pages/Admin/Pages/Index.test.ts
@@ -42,6 +42,7 @@ const makePage = (overrides: Partial<Page> = {}): Page => ({
     excerpt: null, status: 'published', meta_title: null, meta_description: null, meta_keywords: null,
     published_at: '2025-01-01 10:00:00', created_at: '2025-01-01 10:00:00', updated_at: '2025-01-01 10:00:00',
     author: { id: 1, name: 'Alice', email: 'a@example.com', role: 'super_admin', locale: 'en', last_login_at: null, theme_mode: 'system', timezone: 'UTC' },
+    parent_id: null, parent: null,
     ...overrides,
 })
 

--- a/laravel/resources/js/tests/Pages/Admin/Posts/Edit.test.ts
+++ b/laravel/resources/js/tests/Pages/Admin/Posts/Edit.test.ts
@@ -12,7 +12,7 @@ const post: Post = {
     excerpt: null, status: 'draft', meta_title: null, meta_description: null, meta_keywords: null,
     published_at: null, created_at: '2025-01-01 10:00:00', updated_at: '2025-01-01 10:00:00',
     featured_image: 'https://example.com/img.jpg', category_id: 2, category: null,
-    tags: [{ id: 1, name: 'Laravel', slug: 'laravel' }], author,
+    tags: [{ id: 1, name: 'Laravel', slug: 'laravel' }], author, parent_id: null, parent: null,
 }
 
 const categories: Category[] = [

--- a/laravel/resources/js/tests/Pages/Admin/Posts/Index.test.ts
+++ b/laravel/resources/js/tests/Pages/Admin/Posts/Index.test.ts
@@ -43,7 +43,7 @@ const makePost = (overrides: Partial<Post> = {}): Post => ({
     id: 1, user_id: 1, title: 'Hello World', slug: 'hello-world', content: '<p>Hi</p>', content_json: {},
     excerpt: null, status: 'published', meta_title: null, meta_description: null, meta_keywords: null,
     published_at: '2025-01-01 10:00:00', created_at: '2025-01-01 10:00:00', updated_at: '2025-01-01 10:00:00',
-    featured_image: null, category_id: null, category: null, tags: [], author,
+    featured_image: null, category_id: null, category: null, tags: [], author, parent_id: null, parent: null,
     ...overrides,
 })
 

--- a/laravel/resources/js/types/models.ts
+++ b/laravel/resources/js/types/models.ts
@@ -62,6 +62,8 @@ export interface Page {
     created_at: string;
     updated_at: string;
     author: AuthUser;
+    parent_id: number | null;
+    parent: Pick<Page, "id" | "slug" | "title"> | null;
 }
 
 export interface Post extends Page {

--- a/laravel/tests/Feature/Admin/PageControllerTest.php
+++ b/laravel/tests/Feature/Admin/PageControllerTest.php
@@ -455,4 +455,97 @@ class PageControllerTest extends TestCase
         // Act + Assert
         $this->actingAs($user)->delete("/admin/pages/{$page->id}")->assertForbidden();
     }
+
+    // ─── parent_id validation ─────────────────────────────────────────────────
+
+    public function test_store_accepts_valid_parent_id(): void
+    {
+        // Arrange
+        $user   = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $parent = Page::factory()->create();
+
+        // Act
+        $this->actingAs($user)->post('/admin/pages', [
+            'title'     => 'Child Page',
+            'content'   => 'Body',
+            'status'    => 'draft',
+            'parent_id' => $parent->id,
+        ]);
+
+        // Assert
+        $this->assertDatabaseHas('pages', [
+            'title'     => 'Child Page',
+            'parent_id' => $parent->id,
+        ]);
+    }
+
+    public function test_store_rejects_non_existent_parent_id(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post('/admin/pages', [
+                'title'     => 'Child Page',
+                'content'   => 'Body',
+                'status'    => 'draft',
+                'parent_id' => 99999,
+            ])
+            ->assertSessionHasErrors('parent_id');
+    }
+
+    public function test_update_accepts_valid_parent_id(): void
+    {
+        // Arrange
+        $user   = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $parent = Page::factory()->create();
+        $page   = Page::factory()->create();
+
+        // Act
+        $this->actingAs($user)->put("/admin/pages/{$page->id}", [
+            'title'     => 'Updated',
+            'content'   => 'Body',
+            'status'    => 'draft',
+            'parent_id' => $parent->id,
+        ]);
+
+        // Assert
+        $this->assertDatabaseHas('pages', ['id' => $page->id, 'parent_id' => $parent->id]);
+    }
+
+    public function test_update_rejects_assigning_page_as_its_own_parent(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $page = Page::factory()->create();
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->put("/admin/pages/{$page->id}", [
+                'title'     => 'Title',
+                'content'   => 'Body',
+                'status'    => 'draft',
+                'parent_id' => $page->id,
+            ])
+            ->assertSessionHasErrors('parent_id');
+    }
+
+    public function test_update_rejects_assigning_descendant_as_parent(): void
+    {
+        // Arrange
+        $user  = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $page  = Page::factory()->create();
+        $child = Page::factory()->create(['parent_id' => $page->id]);
+
+        // Act + Assert — trying to make the ancestor a child of its own descendant
+        $this->actingAs($user)
+            ->put("/admin/pages/{$page->id}", [
+                'title'     => 'Title',
+                'content'   => 'Body',
+                'status'    => 'draft',
+                'parent_id' => $child->id,
+            ])
+            ->assertSessionHasErrors('parent_id');
+    }
 }

--- a/laravel/tests/Unit/Models/PageTest.php
+++ b/laravel/tests/Unit/Models/PageTest.php
@@ -74,4 +74,67 @@ class PageTest extends TestCase
         // Assert
         $this->assertSoftDeleted('pages', ['id' => $page->id]);
     }
+
+    // ─── parent / children relationships ─────────────────────────────────────
+
+    public function test_parent_relationship_returns_parent_page(): void
+    {
+        // Arrange
+        $parent = Page::factory()->create();
+        $child  = Page::factory()->create(['parent_id' => $parent->id]);
+
+        // Act + Assert
+        $this->assertTrue($child->parent->is($parent));
+    }
+
+    public function test_children_relationship_returns_child_pages(): void
+    {
+        // Arrange
+        $parent   = Page::factory()->create();
+        $childOne = Page::factory()->create(['parent_id' => $parent->id]);
+        $childTwo = Page::factory()->create(['parent_id' => $parent->id]);
+        Page::factory()->create(); // unrelated
+
+        // Act
+        $children = $parent->children;
+
+        // Assert
+        $this->assertCount(2, $children);
+        $this->assertTrue($children->contains($childOne));
+        $this->assertTrue($children->contains($childTwo));
+    }
+
+    // ─── isDescendantOf ───────────────────────────────────────────────────────
+
+    public function test_is_descendant_of_returns_true_for_direct_parent(): void
+    {
+        // Arrange
+        $parent = Page::factory()->create();
+        $child  = Page::factory()->create(['parent_id' => $parent->id]);
+
+        // Act + Assert
+        $this->assertTrue($child->isDescendantOf($parent));
+    }
+
+    public function test_is_descendant_of_returns_true_for_grandparent(): void
+    {
+        // Arrange
+        $grandparent = Page::factory()->create();
+        $parent      = Page::factory()->create(['parent_id' => $grandparent->id]);
+        $child       = Page::factory()->create(['parent_id' => $parent->id]);
+
+        // Act + Assert — load parent chain before calling
+        $child->load('parent.parent');
+        $this->assertTrue($child->isDescendantOf($grandparent));
+    }
+
+    public function test_is_descendant_of_returns_false_for_unrelated_page(): void
+    {
+        // Arrange
+        $pageA = Page::factory()->create();
+        $pageB = Page::factory()->create();
+
+        // Act + Assert
+        $this->assertFalse($pageB->isDescendantOf($pageA));
+    }
 }

--- a/plan.md
+++ b/plan.md
@@ -75,7 +75,7 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 | ✅ | [#158](https://github.com/Three-Hoops/Hoops-CMS/issues/158) | Add controllers, form requests, and policies for content types | `content`, `enhancement` |
 | ✅ | [#159](https://github.com/Three-Hoops/Hoops-CMS/issues/159) | Register admin resource routes for content types | `content`, `enhancement` |
 | ✅ | [#160](https://github.com/Three-Hoops/Hoops-CMS/issues/160) | Build Vue pages and shared components for content management | `content`, `enhancement` |
-| ⬜ | [#76](https://github.com/Three-Hoops/Hoops-CMS/issues/76) | Add parent_id to pages table for hierarchical page structure | `content`, `enhancement` |
+| ✅ | [#76](https://github.com/Three-Hoops/Hoops-CMS/issues/76) | Add parent_id to pages table for hierarchical page structure | `content`, `enhancement` |
 | ⬜ | [#85](https://github.com/Three-Hoops/Hoops-CMS/issues/85) | Add duplicate action for posts and pages | `content`, `enhancement` |
 | ⬜ | [#65](https://github.com/Three-Hoops/Hoops-CMS/issues/65) | Add per-post and per-page Open Graph / social meta fields | `content`, `enhancement` |
 | ⬜ | [#69](https://github.com/Three-Hoops/Hoops-CMS/issues/69) | Add featured/pinned flag to posts | `content`, `enhancement` |


### PR DESCRIPTION
Closes #76

## Summary
- Adds nullable `parent_id` FK (with index) to the `pages` migration
- Adds `parent()` / `children()` relationships and `isDescendantOf()` to the `Page` model
- Validates `parent_id` in `StorePage` and `UpdatePage` — rejects non-existent IDs, self-reference, and circular ancestor assignment
- Passes pages list to create/edit controllers; index eager-loads `parent`
- Parent page selector added to Create and Edit forms; Parent column added to index table
- PHP unit tests for relationships and `isDescendantOf`; feature tests for all validation cases

## Test plan
- [ ] `php artisan test --filter PageTest` — all unit tests pass
- [ ] `php artisan test --filter PageControllerTest` — all feature tests pass
- [ ] `pnpm test` — all Vue component tests pass
- [x] Create two pages; edit the first and confirm the second appears in the parent dropdown
- [ ] Confirm a page cannot be set as its own parent (validation error)
- [ ] Confirm a parent page shows in the Parent column on the index table

🤖 Generated with [Claude Code](https://claude.com/claude-code)