### PR TITLE
Add missing indexes to content migrations

### DIFF
--- a/laravel/database/migrations/2026_04_20_092426_create_pages_table.php
+++ b/laravel/database/migrations/2026_04_20_092426_create_pages_table.php
@@ -27,6 +27,7 @@ return new class extends Migration
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->timestamp('published_at')->nullable();
             $table->softDeletes();
+            $table->index('deleted_at');
             $table->index('status');
             $table->index('published_at');
             $table->foreignId('parent_id')->nullable()->constrained('pages')->nullOnDelete();

--- a/laravel/database/migrations/2026_04_20_092426_create_posts_table.php
+++ b/laravel/database/migrations/2026_04_20_092426_create_posts_table.php
@@ -29,6 +29,7 @@ return new class extends Migration
             $table->foreignId('category_id')->nullable()->constrained()->nullOnDelete();
             $table->timestamp('published_at')->nullable();
             $table->softDeletes();
+            $table->index('deleted_at');
             $table->index('status');
             $table->index('published_at');
             $table->index('category_id');

--- a/laravel/database/migrations/2026_04_20_092427_create_post_tag_table.php
+++ b/laravel/database/migrations/2026_04_20_092427_create_post_tag_table.php
@@ -15,6 +15,7 @@ return new class extends Migration
             $table->foreignId('post_id')->constrained()->cascadeOnDelete();
             $table->foreignId('tag_id')->constrained()->cascadeOnDelete();
             $table->primary(['post_id','tag_id']);
+            $table->index('tag_id');
         });
     }
 

--- a/plan.md
+++ b/plan.md
@@ -80,7 +80,7 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 | ⬜ | [#65](https://github.com/Three-Hoops/Hoops-CMS/issues/65) | Add per-post and per-page Open Graph / social meta fields | `content`, `enhancement` |
 | ⬜ | [#69](https://github.com/Three-Hoops/Hoops-CMS/issues/69) | Add featured/pinned flag to posts | `content`, `enhancement` |
 | ⬜ | [#17](https://github.com/Three-Hoops/Hoops-CMS/issues/17) | Add soft deletes to content models | `content` |
-| ⬜ | [#40](https://github.com/Three-Hoops/Hoops-CMS/issues/40) | Add database indexes to content migrations | `performance` |
+| ✅ | [#40](https://github.com/Three-Hoops/Hoops-CMS/issues/40) | Add database indexes to content migrations | `performance` |
 | ⬜ | [#43](https://github.com/Three-Hoops/Hoops-CMS/issues/43) | Handle slug collisions with auto-increment | `content` |
 | ⬜ | [#45](https://github.com/Three-Hoops/Hoops-CMS/issues/45) | Wrap multi-step writes in database transactions | `content` |
 | ⬜ | [#38](https://github.com/Three-Hoops/Hoops-CMS/issues/38) | Sanitise TipTap HTML output to prevent XSS | `security`, `content` |


### PR DESCRIPTION
Closes #40

## Summary
- Added `deleted_at` index to `posts` and `pages` for soft-delete scope performance
- Added `tag_id` index to `post_tag` for reverse pivot lookups (tag → posts)

All other query-critical columns (`status`, `published_at`, `category_id`, `parent_id`, `slug`) were already indexed in the original migrations.

## Test plan
- [x] `php artisan test` — 202 tests pass (no new tests needed; migrations are covered by `migrate:fresh` in the test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)