### PR TITLE
Wrap post store/update in DB transactions

### DIFF
--- a/laravel/app/Http/Controllers/Admin/PostController.php
+++ b/laravel/app/Http/Controllers/Admin/PostController.php
@@ -12,6 +12,7 @@ use App\Models\Post;
 use App\Models\Tag;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -58,8 +59,12 @@ class PostController extends Controller
             $validated['published_at'] = now();
         }
 
-        $post = Post::create($validated);
-        $post->tags()->sync($tagIds);
+        $post = DB::transaction(function () use ($validated, $tagIds) {
+            $post = Post::create($validated);
+            $post->tags()->sync($tagIds);
+
+            return $post;
+        });
 
         return redirect()
             ->route('admin.posts.index')
@@ -93,8 +98,10 @@ class PostController extends Controller
             $validated['published_at'] = now();
         }
 
-        $post->update($validated);
-        $post->tags()->sync($tagIds);
+        DB::transaction(function () use ($post, $validated, $tagIds) {
+            $post->update($validated);
+            $post->tags()->sync($tagIds);
+        });
 
         return redirect()
             ->route('admin.posts.index')

--- a/plan.md
+++ b/plan.md
@@ -84,7 +84,7 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 | ✅ | [#17](https://github.com/Three-Hoops/Hoops-CMS/issues/17) | Add soft deletes to content models | `content` |
 | ⬜ | [#40](https://github.com/Three-Hoops/Hoops-CMS/issues/40) | Add database indexes to content migrations | `performance` |
 | ⬜ | [#43](https://github.com/Three-Hoops/Hoops-CMS/issues/43) | Handle slug collisions with auto-increment | `content` |
-| ⬜ | [#45](https://github.com/Three-Hoops/Hoops-CMS/issues/45) | Wrap multi-step writes in database transactions | `content` |
+| ✅ | [#45](https://github.com/Three-Hoops/Hoops-CMS/issues/45) | Wrap multi-step writes in database transactions | `content` |
 | ⬜ | [#38](https://github.com/Three-Hoops/Hoops-CMS/issues/38) | Sanitise TipTap HTML output to prevent XSS | `security`, `content` |
 | ⬜ | [#68](https://github.com/Three-Hoops/Hoops-CMS/issues/68) | Add autosave for rich text editor to prevent data loss | `content`, `enhancement` |
 | ⬜ | [#110](https://github.com/Three-Hoops/Hoops-CMS/issues/110) | Warn users about unsaved changes before navigating away | `content`, `enhancement` |


### PR DESCRIPTION
Closes #45

## Summary
- `PostController::store` and `PostController::update` both write to two tables (`posts` and the `post_tag` pivot). Wrapped both in `DB::transaction()` so a failure during `tags()->sync()` rolls back the post write, preventing partial/inconsistent state.
- Pages, categories, and tags are single-table writes — no transaction needed there.

## Test plan
- [x] `php artisan test` — 217 tests pass, all existing tag-sync assertions still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)