### PR TITLE
Handle slug collisions with auto-increment (#43)

### DIFF
--- a/laravel/app/Http/Controllers/Admin/CategoryController.php
+++ b/laravel/app/Http/Controllers/Admin/CategoryController.php
@@ -7,8 +7,8 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\StoreCategory;
 use App\Http\Requests\Admin\UpdateCategory;
 use App\Models\Category;
+use App\Support\UniqueSlug;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -43,7 +43,7 @@ class CategoryController extends Controller
     public function store(StoreCategory $request): RedirectResponse
     {
         $validated = $request->validated();
-        $validated['slug'] ??= Str::slug($validated['name']);
+        $validated['slug'] = UniqueSlug::generate($validated['slug'] ?? $validated['name'], 'categories');
 
         Category::create($validated);
 
@@ -67,7 +67,7 @@ class CategoryController extends Controller
     public function update(UpdateCategory $request, Category $category): RedirectResponse
     {
         $validated = $request->validated();
-        $validated['slug'] ??= Str::slug($validated['name']);
+        $validated['slug'] = UniqueSlug::generate($validated['slug'] ?? $validated['name'], 'categories', $category->id);
 
         $category->update($validated);
 

--- a/laravel/app/Http/Controllers/Admin/PageController.php
+++ b/laravel/app/Http/Controllers/Admin/PageController.php
@@ -8,8 +8,8 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\StorePage;
 use App\Http\Requests\Admin\UpdatePage;
 use App\Models\Page;
+use App\Support\UniqueSlug;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -44,7 +44,7 @@ class PageController extends Controller
     public function store(StorePage $request): RedirectResponse
     {
         $validated = $request->validated();
-        $validated['slug']         ??= Str::slug($validated['title']);
+        $validated['slug']         = UniqueSlug::generate($validated['slug'] ?? $validated['title'], 'pages');
         $validated['content_json'] ??= [];
         $validated['user_id']        = $request->user()->id;
 
@@ -72,7 +72,7 @@ class PageController extends Controller
     public function update(UpdatePage $request, Page $page): RedirectResponse
     {
         $validated = $request->validated();
-        $validated['slug']         ??= Str::slug($validated['title']);
+        $validated['slug']         = UniqueSlug::generate($validated['slug'] ?? $validated['title'], 'pages', $page->id);
         $validated['content_json'] ??= [];
 
         if (

--- a/laravel/app/Http/Controllers/Admin/PostController.php
+++ b/laravel/app/Http/Controllers/Admin/PostController.php
@@ -10,10 +10,10 @@ use App\Http\Requests\Admin\UpdatePost;
 use App\Models\Category;
 use App\Models\Post;
 use App\Models\Tag;
+use App\Support\UniqueSlug;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -51,7 +51,7 @@ class PostController extends Controller
         $validated = $request->validated();
         $tagIds    = Arr::pull($validated, 'tag_ids', []);
 
-        $validated['slug']         ??= Str::slug($validated['title']);
+        $validated['slug']         = UniqueSlug::generate($validated['slug'] ?? $validated['title'], 'posts');
         $validated['content_json'] ??= [];
         $validated['user_id']        = $request->user()->id;
 
@@ -87,7 +87,7 @@ class PostController extends Controller
         $validated = $request->validated();
         $tagIds    = Arr::pull($validated, 'tag_ids', []);
 
-        $validated['slug']         ??= Str::slug($validated['title']);
+        $validated['slug']         = UniqueSlug::generate($validated['slug'] ?? $validated['title'], 'posts', $post->id);
         $validated['content_json'] ??= [];
 
         if (

--- a/laravel/app/Http/Controllers/Admin/TagController.php
+++ b/laravel/app/Http/Controllers/Admin/TagController.php
@@ -7,8 +7,8 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\StoreTag;
 use App\Http\Requests\Admin\UpdateTag;
 use App\Models\Tag;
+use App\Support\UniqueSlug;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -28,7 +28,7 @@ class TagController extends Controller
     public function store(StoreTag $request): RedirectResponse
     {
         $validated = $request->validated();
-        $validated['slug'] ??= Str::slug($validated['name']);
+        $validated['slug'] = UniqueSlug::generate($validated['slug'] ?? $validated['name'], 'tags');
 
         Tag::create($validated);
 
@@ -40,7 +40,7 @@ class TagController extends Controller
     public function update(UpdateTag $request, Tag $tag): RedirectResponse
     {
         $validated = $request->validated();
-        $validated['slug'] ??= Str::slug($validated['name']);
+        $validated['slug'] = UniqueSlug::generate($validated['slug'] ?? $validated['name'], 'tags', $tag->id);
 
         $tag->update($validated);
 

--- a/laravel/app/Http/Requests/Admin/StoreCategory.php
+++ b/laravel/app/Http/Requests/Admin/StoreCategory.php
@@ -17,7 +17,7 @@ class StoreCategory extends FormRequest
     {
         return [
             'name'        => ['required', 'string', 'max:255'],
-            'slug'        => ['nullable', 'string', 'max:255', Rule::unique('categories', 'slug')],
+            'slug'        => ['nullable', 'string', 'max:255'],
             'description' => ['nullable', 'string', 'max:1000'],
             'parent_id'   => ['nullable', 'integer', Rule::exists('categories', 'id')],
         ];

--- a/laravel/app/Http/Requests/Admin/StorePage.php
+++ b/laravel/app/Http/Requests/Admin/StorePage.php
@@ -18,7 +18,7 @@ class StorePage extends FormRequest
     {
         return [
             'title'            => ['required', 'string', 'max:255'],
-            'slug'             => ['nullable', 'string', 'max:255', Rule::unique('pages', 'slug')],
+            'slug'             => ['nullable', 'string', 'max:255'],
             'content'          => ['required', 'string'],
             'content_json'     => ['nullable', 'array'],
             'excerpt'          => ['nullable', 'string', 'max:1000'],

--- a/laravel/app/Http/Requests/Admin/StorePost.php
+++ b/laravel/app/Http/Requests/Admin/StorePost.php
@@ -18,7 +18,7 @@ class StorePost extends FormRequest
     {
         return [
             'title'            => ['required', 'string', 'max:255'],
-            'slug'             => ['nullable', 'string', 'max:255', Rule::unique('posts', 'slug')],
+            'slug'             => ['nullable', 'string', 'max:255'],
             'content'          => ['required', 'string'],
             'content_json'     => ['nullable', 'array'],
             'excerpt'          => ['nullable', 'string', 'max:1000'],

--- a/laravel/app/Http/Requests/Admin/StoreTag.php
+++ b/laravel/app/Http/Requests/Admin/StoreTag.php
@@ -4,7 +4,6 @@ namespace App\Http\Requests\Admin;
 
 use App\Models\Tag;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
 
 class StoreTag extends FormRequest
 {
@@ -17,7 +16,7 @@ class StoreTag extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
-            'slug' => ['nullable', 'string', 'max:255', Rule::unique('tags', 'slug')],
+            'slug' => ['nullable', 'string', 'max:255'],
         ];
     }
 }

--- a/laravel/app/Http/Requests/Admin/UpdateCategory.php
+++ b/laravel/app/Http/Requests/Admin/UpdateCategory.php
@@ -18,7 +18,7 @@ class UpdateCategory extends FormRequest
 
         return [
             'name'        => ['required', 'string', 'max:255'],
-            'slug'        => ['nullable', 'string', 'max:255', Rule::unique('categories', 'slug')->ignore($categoryId)],
+            'slug'        => ['nullable', 'string', 'max:255'],
             'description' => ['nullable', 'string', 'max:1000'],
             'parent_id'   => [
                 'nullable',

--- a/laravel/app/Http/Requests/Admin/UpdatePage.php
+++ b/laravel/app/Http/Requests/Admin/UpdatePage.php
@@ -21,7 +21,7 @@ class UpdatePage extends FormRequest
 
         return [
             'title'            => ['required', 'string', 'max:255'],
-            'slug'             => ['nullable', 'string', 'max:255', Rule::unique('pages', 'slug')->ignore($pageId)],
+            'slug'             => ['nullable', 'string', 'max:255'],
             'content'          => ['required', 'string'],
             'content_json'     => ['nullable', 'array'],
             'excerpt'          => ['nullable', 'string', 'max:1000'],

--- a/laravel/app/Http/Requests/Admin/UpdatePost.php
+++ b/laravel/app/Http/Requests/Admin/UpdatePost.php
@@ -15,11 +15,9 @@ class UpdatePost extends FormRequest
 
     public function rules(): array
     {
-        $postId = $this->route('post')->id;
-
         return [
             'title'            => ['required', 'string', 'max:255'],
-            'slug'             => ['nullable', 'string', 'max:255', Rule::unique('posts', 'slug')->ignore($postId)],
+            'slug'             => ['nullable', 'string', 'max:255'],
             'content'          => ['required', 'string'],
             'content_json'     => ['nullable', 'array'],
             'excerpt'          => ['nullable', 'string', 'max:1000'],

--- a/laravel/app/Http/Requests/Admin/UpdateTag.php
+++ b/laravel/app/Http/Requests/Admin/UpdateTag.php
@@ -3,7 +3,6 @@
 namespace App\Http\Requests\Admin;
 
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
 
 class UpdateTag extends FormRequest
 {
@@ -14,11 +13,9 @@ class UpdateTag extends FormRequest
 
     public function rules(): array
     {
-        $tagId = $this->route('tag')->id;
-
         return [
             'name' => ['required', 'string', 'max:255'],
-            'slug' => ['nullable', 'string', 'max:255', Rule::unique('tags', 'slug')->ignore($tagId)],
+            'slug' => ['nullable', 'string', 'max:255'],
         ];
     }
 }

--- a/laravel/app/Support/UniqueSlug.php
+++ b/laravel/app/Support/UniqueSlug.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class UniqueSlug
+{
+    public static function generate(string $base, string $table, ?int $ignoreId = null): string
+    {
+        $base = Str::slug($base);
+        $slug = $base;
+        $counter = 1;
+
+        while (
+            DB::table($table)
+                ->where('slug', $slug)
+                ->when($ignoreId, fn ($q) => $q->where('id', '!=', $ignoreId))
+                ->exists()
+        ) {
+            $slug = "{$base}-{$counter}";
+            $counter++;
+        }
+
+        return $slug;
+    }
+}

--- a/laravel/tests/Feature/Admin/CategoryControllerTest.php
+++ b/laravel/tests/Feature/Admin/CategoryControllerTest.php
@@ -153,16 +153,19 @@ class CategoryControllerTest extends TestCase
             ->assertSessionHasErrors('parent_id');
     }
 
-    public function test_store_rejects_duplicate_slug(): void
+    public function test_store_auto_increments_duplicate_slug(): void
     {
         // Arrange
         $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
         Category::factory()->create(['slug' => 'existing']);
 
-        // Act + Assert
+        // Act
         $this->actingAs($user)
             ->post('/admin/categories', ['name' => 'Whatever', 'slug' => 'existing'])
-            ->assertSessionHasErrors('slug');
+            ->assertRedirect('/admin/categories');
+
+        // Assert
+        $this->assertDatabaseHas('categories', ['slug' => 'existing-1']);
     }
 
     public function test_store_requires_name(): void

--- a/laravel/tests/Feature/Admin/PageControllerTest.php
+++ b/laravel/tests/Feature/Admin/PageControllerTest.php
@@ -234,13 +234,13 @@ class PageControllerTest extends TestCase
             ->assertSessionHasErrors('status');
     }
 
-    public function test_store_rejects_duplicate_slug(): void
+    public function test_store_auto_increments_duplicate_slug(): void
     {
         // Arrange
         $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
         Page::factory()->create(['slug' => 'existing-slug']);
 
-        // Act + Assert
+        // Act
         $this->actingAs($user)
             ->post('/admin/pages', [
                 'title'   => 'Title',
@@ -248,7 +248,10 @@ class PageControllerTest extends TestCase
                 'content' => 'Body',
                 'status'  => 'draft',
             ])
-            ->assertSessionHasErrors('slug');
+            ->assertRedirect('/admin/pages');
+
+        // Assert
+        $this->assertDatabaseHas('pages', ['slug' => 'existing-slug-1']);
     }
 
     // ─── edit ─────────────────────────────────────────────────────────────────

--- a/laravel/tests/Feature/Admin/PostControllerTest.php
+++ b/laravel/tests/Feature/Admin/PostControllerTest.php
@@ -274,13 +274,13 @@ class PostControllerTest extends TestCase
             ->assertSessionHasErrors('status');
     }
 
-    public function test_store_rejects_duplicate_slug(): void
+    public function test_store_auto_increments_duplicate_slug(): void
     {
         // Arrange
         $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
         Post::factory()->create(['slug' => 'existing-slug']);
 
-        // Act + Assert
+        // Act
         $this->actingAs($user)
             ->post('/admin/posts', [
                 'title'   => 'Title',
@@ -288,7 +288,30 @@ class PostControllerTest extends TestCase
                 'content' => 'Body',
                 'status'  => 'draft',
             ])
-            ->assertSessionHasErrors('slug');
+            ->assertRedirect('/admin/posts');
+
+        // Assert
+        $this->assertDatabaseHas('posts', ['slug' => 'existing-slug-1']);
+    }
+
+    public function test_store_auto_increments_slug_derived_from_title_on_collision(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        Post::factory()->create(['slug' => 'duplicate-title']);
+        Post::factory()->create(['slug' => 'duplicate-title-1']);
+
+        // Act
+        $this->actingAs($user)
+            ->post('/admin/posts', [
+                'title'   => 'Duplicate Title',
+                'content' => 'Body',
+                'status'  => 'draft',
+            ])
+            ->assertRedirect('/admin/posts');
+
+        // Assert
+        $this->assertDatabaseHas('posts', ['slug' => 'duplicate-title-2']);
     }
 
     public function test_store_validates_category_exists(): void
@@ -487,14 +510,14 @@ class PostControllerTest extends TestCase
             ->assertRedirect('/admin/posts');
     }
 
-    public function test_update_rejects_slug_already_used_by_another_post(): void
+    public function test_update_auto_increments_slug_already_used_by_another_post(): void
     {
         // Arrange
         $user  = User::factory()->create(['role' => UserRole::SuperAdmin]);
         $other = Post::factory()->create(['slug' => 'taken-slug']);
         $post  = Post::factory()->create(['slug' => 'my-post']);
 
-        // Act + Assert
+        // Act
         $this->actingAs($user)
             ->put("/admin/posts/{$post->id}", [
                 'title'   => 'My Post',
@@ -502,7 +525,10 @@ class PostControllerTest extends TestCase
                 'content' => 'Body',
                 'status'  => 'draft',
             ])
-            ->assertSessionHasErrors('slug');
+            ->assertRedirect('/admin/posts');
+
+        // Assert
+        $this->assertDatabaseHas('posts', ['id' => $post->id, 'slug' => 'taken-slug-1']);
     }
 
     public function test_update_does_not_reset_published_at(): void

--- a/laravel/tests/Feature/Admin/TagControllerTest.php
+++ b/laravel/tests/Feature/Admin/TagControllerTest.php
@@ -98,16 +98,19 @@ class TagControllerTest extends TestCase
             ->assertSessionHasErrors('name');
     }
 
-    public function test_store_rejects_duplicate_slug(): void
+    public function test_store_auto_increments_duplicate_slug(): void
     {
         // Arrange
         $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
         Tag::factory()->create(['slug' => 'php']);
 
-        // Act + Assert
+        // Act
         $this->actingAs($user)
             ->post('/admin/tags', ['name' => 'Anything', 'slug' => 'php'])
-            ->assertSessionHasErrors('slug');
+            ->assertRedirect('/admin/tags');
+
+        // Assert
+        $this->assertDatabaseHas('tags', ['slug' => 'php-1']);
     }
 
     // ─── update ───────────────────────────────────────────────────────────────

--- a/laravel/tests/Unit/UniqueSlugTest.php
+++ b/laravel/tests/Unit/UniqueSlugTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Post;
+use App\Models\User;
+use App\Support\UniqueSlug;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UniqueSlugTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_returns_base_slug_when_no_collision(): void
+    {
+        // Arrange + Act
+        $slug = UniqueSlug::generate('My Post', 'posts');
+
+        // Assert
+        $this->assertSame('my-post', $slug);
+    }
+
+    public function test_increments_to_1_when_base_slug_exists(): void
+    {
+        // Arrange
+        Post::factory()->create(['slug' => 'my-post']);
+
+        // Act
+        $slug = UniqueSlug::generate('My Post', 'posts');
+
+        // Assert
+        $this->assertSame('my-post-1', $slug);
+    }
+
+    public function test_increments_to_2_when_base_and_1_both_exist(): void
+    {
+        // Arrange
+        Post::factory()->create(['slug' => 'my-post']);
+        Post::factory()->create(['slug' => 'my-post-1']);
+
+        // Act
+        $slug = UniqueSlug::generate('My Post', 'posts');
+
+        // Assert
+        $this->assertSame('my-post-2', $slug);
+    }
+
+    public function test_ignore_id_allows_keeping_own_slug(): void
+    {
+        // Arrange
+        $post = Post::factory()->create(['slug' => 'my-post']);
+
+        // Act
+        $slug = UniqueSlug::generate('my-post', 'posts', $post->id);
+
+        // Assert
+        $this->assertSame('my-post', $slug);
+    }
+
+    public function test_ignore_id_still_increments_when_another_record_has_slug(): void
+    {
+        // Arrange
+        $post        = Post::factory()->create(['slug' => 'my-post']);
+        $otherPost   = Post::factory()->create(['slug' => 'other-post']);
+
+        // Act — trying to claim 'other-post' but it belongs to a different record
+        $slug = UniqueSlug::generate('other-post', 'posts', $post->id);
+
+        // Assert
+        $this->assertSame('other-post-1', $slug);
+    }
+
+    public function test_slugifies_input_title(): void
+    {
+        // Arrange + Act
+        $slug = UniqueSlug::generate('Hello World! This is a Test', 'posts');
+
+        // Assert
+        $this->assertSame('hello-world-this-is-a-test', $slug);
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -83,7 +83,7 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 | ✅ | [#40](https://github.com/Three-Hoops/Hoops-CMS/issues/40) | Add database indexes to content migrations | `performance` |
 | ✅ | [#17](https://github.com/Three-Hoops/Hoops-CMS/issues/17) | Add soft deletes to content models | `content` |
 | ⬜ | [#40](https://github.com/Three-Hoops/Hoops-CMS/issues/40) | Add database indexes to content migrations | `performance` |
-| ⬜ | [#43](https://github.com/Three-Hoops/Hoops-CMS/issues/43) | Handle slug collisions with auto-increment | `content` |
+| ✅ | [#43](https://github.com/Three-Hoops/Hoops-CMS/issues/43) | Handle slug collisions with auto-increment | `content` |
 | ✅ | [#45](https://github.com/Three-Hoops/Hoops-CMS/issues/45) | Wrap multi-step writes in database transactions | `content` |
 | ⬜ | [#38](https://github.com/Three-Hoops/Hoops-CMS/issues/38) | Sanitise TipTap HTML output to prevent XSS | `security`, `content` |
 | ⬜ | [#68](https://github.com/Three-Hoops/Hoops-CMS/issues/68) | Add autosave for rich text editor to prevent data loss | `content`, `enhancement` |


### PR DESCRIPTION
Closes #43

## Summary

- Adds `App\Support\UniqueSlug::generate(base, table, ignoreId?)` — loops until a unique slug is found, appending `-1`, `-2`, … as needed
- Removes `Rule::unique()` from the slug field in all eight form request classes (Store/Update for Post, Page, Category, Tag)
- Updates all four content controllers to call `UniqueSlug::generate()` instead of the bare `Str::slug()` fallback, for both `store` and `update` actions
- Applies to all sluggable models: `Post`, `Page`, `Category`, `Tag`

## Test plan

- [ ] `php artisan test` — all 224 tests pass
- [ ] New `UniqueSlugTest` unit tests cover: no collision, increment to `-1`, increment to `-2`, `ignoreId` keeps own slug, `ignoreId` still increments for a different record's slug, input slugification
- [ ] Existing duplicate-slug feature tests updated across all four controller test files to assert auto-increment rather than a validation error
- [ ] Manual smoke test: create two posts with the same title, confirm second gets `-1`; create a third, confirm `-2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)