### PR TITLE
Add duplicate action for posts and pages

### DIFF
--- a/laravel/app/Http/Controllers/Admin/PageController.php
+++ b/laravel/app/Http/Controllers/Admin/PageController.php
@@ -107,6 +107,30 @@ class PageController extends Controller
         return response()->json(['saved_at' => now()->toISOString()]);
     }
 
+    public function duplicate(Page $page): RedirectResponse
+    {
+        $this->authorize('duplicate', $page);
+
+        $new = Page::create([
+            'title'            => $page->title . ' (Copy)',
+            'slug'             => UniqueSlug::generate($page->title . ' Copy', 'pages'),
+            'content'          => $page->content,
+            'content_json'     => $page->content_json ?? [],
+            'excerpt'          => $page->excerpt,
+            'status'           => ContentStatus::Draft,
+            'meta_title'       => $page->meta_title,
+            'meta_description' => $page->meta_description,
+            'meta_keywords'    => $page->meta_keywords,
+            'parent_id'        => $page->parent_id,
+            'user_id'          => auth()->id(),
+            'published_at'     => null,
+        ]);
+
+        return redirect()
+            ->route('admin.pages.edit', $new)
+            ->with(FlashType::Success->value, 'Page duplicated successfully.');
+    }
+
     public function destroy(Page $page): RedirectResponse
     {
         $this->authorize('delete', $page);

--- a/laravel/app/Http/Controllers/Admin/PostController.php
+++ b/laravel/app/Http/Controllers/Admin/PostController.php
@@ -125,6 +125,37 @@ class PostController extends Controller
         return response()->json(['saved_at' => now()->toISOString()]);
     }
 
+    public function duplicate(Post $post): RedirectResponse
+    {
+        $this->authorize('duplicate', $post);
+
+        $copy = DB::transaction(function () use ($post) {
+            $new = Post::create([
+                'title'            => $post->title . ' (Copy)',
+                'slug'             => UniqueSlug::generate($post->title . ' Copy', 'posts'),
+                'content'          => $post->content,
+                'content_json'     => $post->content_json ?? [],
+                'excerpt'          => $post->excerpt,
+                'status'           => ContentStatus::Draft,
+                'meta_title'       => $post->meta_title,
+                'meta_description' => $post->meta_description,
+                'meta_keywords'    => $post->meta_keywords,
+                'featured_image'   => $post->featured_image,
+                'category_id'      => $post->category_id,
+                'user_id'          => auth()->id(),
+                'published_at'     => null,
+            ]);
+
+            $new->tags()->sync($post->tags->pluck('id'));
+
+            return $new;
+        });
+
+        return redirect()
+            ->route('admin.posts.edit', $copy)
+            ->with(FlashType::Success->value, 'Post duplicated successfully.');
+    }
+
     public function destroy(Post $post): RedirectResponse
     {
         $this->authorize('delete', $post);

--- a/laravel/app/Policies/PagePolicy.php
+++ b/laravel/app/Policies/PagePolicy.php
@@ -23,6 +23,11 @@ class PagePolicy
         return $user->role->canEdit();
     }
 
+    public function duplicate(User $user, Page $page): bool
+    {
+        return $user->role->canEdit();
+    }
+
     public function update(User $user, Page $page): bool
     {
         return $user->role === UserRole::SuperAdmin

--- a/laravel/app/Policies/PostPolicy.php
+++ b/laravel/app/Policies/PostPolicy.php
@@ -23,6 +23,11 @@ class PostPolicy
         return $user->role->canEdit();
     }
 
+    public function duplicate(User $user, Post $post): bool
+    {
+        return $user->role->canEdit();
+    }
+
     public function update(User $user, Post $post): bool
     {
         return $user->role === UserRole::SuperAdmin

--- a/laravel/resources/js/Pages/Admin/Pages/Index.vue
+++ b/laravel/resources/js/Pages/Admin/Pages/Index.vue
@@ -45,6 +45,10 @@ function restore(id: number) {
     router.post(route('admin.pages.restore', id))
 }
 
+function duplicate(id: number) {
+    router.post(route('admin.pages.duplicate', id))
+}
+
 function switchView(toTrash: boolean) {
     router.get(route('admin.pages.index'), toTrash ? { trash: 1 } : {}, { preserveState: false })
 }
@@ -151,6 +155,13 @@ function switchView(toTrash: boolean) {
                     <Link :href="route('admin.pages.edit', page.id)">
                       Edit
                     </Link>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    @click="duplicate(page.id)"
+                  >
+                    Duplicate
                   </Button>
                   <Button
                     variant="destructive"

--- a/laravel/resources/js/Pages/Admin/Posts/Index.vue
+++ b/laravel/resources/js/Pages/Admin/Posts/Index.vue
@@ -46,6 +46,10 @@ function restore(id: number) {
     router.post(route('admin.posts.restore', id))
 }
 
+function duplicate(id: number) {
+    router.post(route('admin.posts.duplicate', id))
+}
+
 function switchView(toTrash: boolean) {
     router.get(route('admin.posts.index'), toTrash ? { trash: 1 } : {}, { preserveState: false })
 }
@@ -165,6 +169,13 @@ function switchView(toTrash: boolean) {
                     <Link :href="route('admin.posts.edit', post.id)">
                       Edit
                     </Link>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    @click="duplicate(post.id)"
+                  >
+                    Duplicate
                   </Button>
                   <Button
                     variant="destructive"

--- a/laravel/resources/js/tests/Pages/Admin/Pages/Index.test.ts
+++ b/laravel/resources/js/tests/Pages/Admin/Pages/Index.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest'
 import PagesIndex from '@/Pages/Admin/Pages/Index.vue'
 import type { Page, Paginated } from '@/types/models'
 
-const { mockDelete } = vi.hoisted(() => ({ mockDelete: vi.fn() }))
+const { mockDelete, mockPost } = vi.hoisted(() => ({ mockDelete: vi.fn(), mockPost: vi.fn() }))
 
 vi.mock('@inertiajs/vue3', () => ({
     usePage: () => ({
@@ -11,7 +11,7 @@ vi.mock('@inertiajs/vue3', () => ({
         props: { app: { name: 'Hoops CMS' }, auth: null, flash: { success: null, error: null }, errors: {}, ziggy: { location: 'http://localhost', routes: {} } },
     }),
     useForm: vi.fn(() => ({ processing: false, errors: {}, post: vi.fn(), reset: vi.fn() })),
-    router: { delete: mockDelete, post: vi.fn(), get: vi.fn() },
+    router: { delete: mockDelete, post: mockPost, get: vi.fn() },
     Head: { template: '<div />' },
     Link: { template: '<a :href="href"><slot /></a>', props: ['href'] },
 }))
@@ -124,5 +124,34 @@ describe('Pages/Index', () => {
 
         // Assert — at least one em-dash present (published_at and parent columns)
         expect(wrapper.text()).toContain('—')
+    })
+
+    it('renders a Duplicate button for each page in non-trash view', () => {
+        // Arrange
+        const wrapper = mount(PagesIndex, { props: { pages, trash: false }, ...globalConfig })
+
+        // Assert
+        const duplicateButtons = wrapper.findAll('button').filter(b => b.text() === 'Duplicate')
+        expect(duplicateButtons).toHaveLength(pages.data.length)
+    })
+
+    it('does not render Duplicate button in trash view', () => {
+        // Arrange
+        const wrapper = mount(PagesIndex, { props: { pages, trash: true }, ...globalConfig })
+
+        // Assert
+        const duplicateButtons = wrapper.findAll('button').filter(b => b.text() === 'Duplicate')
+        expect(duplicateButtons).toHaveLength(0)
+    })
+
+    it('calls router.post with duplicate route when Duplicate is clicked', async () => {
+        // Arrange
+        const wrapper = mount(PagesIndex, { props: { pages, trash: false }, ...globalConfig })
+
+        // Act
+        await wrapper.findAll('button').filter(b => b.text() === 'Duplicate')[0].trigger('click')
+
+        // Assert
+        expect(mockPost).toHaveBeenCalledWith(expect.stringContaining('1'))
     })
 })

--- a/laravel/resources/js/tests/Pages/Admin/Posts/Index.test.ts
+++ b/laravel/resources/js/tests/Pages/Admin/Posts/Index.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest'
 import PostsIndex from '@/Pages/Admin/Posts/Index.vue'
 import type { Post, Paginated } from '@/types/models'
 
-const { mockDelete } = vi.hoisted(() => ({ mockDelete: vi.fn() }))
+const { mockDelete, mockPost } = vi.hoisted(() => ({ mockDelete: vi.fn(), mockPost: vi.fn() }))
 
 vi.mock('@inertiajs/vue3', () => ({
     usePage: () => ({
@@ -11,7 +11,7 @@ vi.mock('@inertiajs/vue3', () => ({
         props: { app: { name: 'Hoops CMS' }, auth: null, flash: { success: null, error: null }, errors: {}, ziggy: { location: 'http://localhost', routes: {} } },
     }),
     useForm: vi.fn(() => ({ processing: false, errors: {}, post: vi.fn() })),
-    router: { delete: mockDelete, post: vi.fn(), get: vi.fn() },
+    router: { delete: mockDelete, post: mockPost, get: vi.fn() },
     Head: { template: '<div />' },
     Link: { template: '<a :href="href"><slot /></a>', props: ['href'] },
 }))
@@ -110,5 +110,34 @@ describe('Posts/Index', () => {
         await wrapper.findAll('button').filter(b => b.text() === 'Delete')[0].trigger('click')
         await wrapper.findComponent({ name: 'ConfirmModal' }).vm.$emit('confirm')
         expect(mockDelete).toHaveBeenCalledWith(expect.stringContaining('1'), expect.any(Object))
+    })
+
+    it('renders a Duplicate button for each post in non-trash view', () => {
+        // Arrange
+        const wrapper = mount(PostsIndex, { props: { posts, trash: false }, ...globalConfig })
+
+        // Assert
+        const duplicateButtons = wrapper.findAll('button').filter(b => b.text() === 'Duplicate')
+        expect(duplicateButtons).toHaveLength(posts.data.length)
+    })
+
+    it('does not render Duplicate button in trash view', () => {
+        // Arrange
+        const wrapper = mount(PostsIndex, { props: { posts, trash: true }, ...globalConfig })
+
+        // Assert
+        const duplicateButtons = wrapper.findAll('button').filter(b => b.text() === 'Duplicate')
+        expect(duplicateButtons).toHaveLength(0)
+    })
+
+    it('calls router.post with duplicate route when Duplicate is clicked', async () => {
+        // Arrange
+        const wrapper = mount(PostsIndex, { props: { posts, trash: false }, ...globalConfig })
+
+        // Act
+        await wrapper.findAll('button').filter(b => b.text() === 'Duplicate')[0].trigger('click')
+
+        // Assert
+        expect(mockPost).toHaveBeenCalledWith(expect.stringContaining('1'))
     })
 })

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -37,11 +37,13 @@ Route::middleware(['auth', 'active', 'session.timeout'])->prefix('admin')->name(
     Route::post('pages/{page}/restore', [PageController::class, 'restore'])->name('pages.restore')->withTrashed();
     Route::delete('pages/{page}/force-delete', [PageController::class, 'forceDelete'])->name('pages.forceDelete')->withTrashed();
     Route::post('pages/{page}/autosave', [PageController::class, 'autosave'])->name('pages.autosave');
+    Route::post('pages/{page}/duplicate', [PageController::class, 'duplicate'])->name('pages.duplicate');
 
     Route::resource('posts', PostController::class)->except('show');
     Route::post('posts/{post}/restore', [PostController::class, 'restore'])->name('posts.restore')->withTrashed();
     Route::delete('posts/{post}/force-delete', [PostController::class, 'forceDelete'])->name('posts.forceDelete')->withTrashed();
     Route::post('posts/{post}/autosave', [PostController::class, 'autosave'])->name('posts.autosave');
+    Route::post('posts/{post}/duplicate', [PostController::class, 'duplicate'])->name('posts.duplicate');
 
     Route::resource('categories', CategoryController::class)->except('show');
     Route::post('categories/{category}/restore', [CategoryController::class, 'restore'])->name('categories.restore')->withTrashed();

--- a/laravel/tests/Feature/Admin/PageControllerTest.php
+++ b/laravel/tests/Feature/Admin/PageControllerTest.php
@@ -719,4 +719,101 @@ class PageControllerTest extends TestCase
             ])
             ->assertSessionHasErrors('parent_id');
     }
+
+    // ─── duplicate ────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_duplicate_any_page(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $page = Page::factory()->create(['title' => 'Original Page', 'status' => ContentStatus::Published]);
+
+        // Act
+        $response = $this->actingAs($user)->post("/admin/pages/{$page->id}/duplicate");
+
+        // Assert
+        $copy = Page::where('title', 'Original Page (Copy)')->first();
+        $this->assertNotNull($copy);
+        $this->assertEquals(ContentStatus::Draft, $copy->status);
+        $this->assertNull($copy->published_at);
+        $this->assertEquals($user->id, $copy->user_id);
+        $response->assertRedirect("/admin/pages/{$copy->id}/edit");
+    }
+
+    public function test_editor_can_duplicate_own_page(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Editor]);
+        $page = Page::factory()->create(['user_id' => $user->id, 'title' => 'My Page']);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post("/admin/pages/{$page->id}/duplicate")
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('pages', ['title' => 'My Page (Copy)', 'user_id' => $user->id]);
+    }
+
+    public function test_editor_can_duplicate_another_editors_page(): void
+    {
+        // Arrange
+        $editor = User::factory()->create(['role' => UserRole::Editor]);
+        $owner  = User::factory()->create(['role' => UserRole::Editor]);
+        $page   = Page::factory()->create(['user_id' => $owner->id, 'title' => 'Shared Page']);
+
+        // Act + Assert — duplicate uses create permission, not ownership
+        $this->actingAs($editor)
+            ->post("/admin/pages/{$page->id}/duplicate")
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('pages', ['title' => 'Shared Page (Copy)', 'user_id' => $editor->id]);
+    }
+
+    public function test_viewer_cannot_duplicate_page(): void
+    {
+        // Arrange
+        $viewer = User::factory()->create(['role' => UserRole::Viewer]);
+        $page   = Page::factory()->create();
+
+        // Act + Assert
+        $this->actingAs($viewer)
+            ->post("/admin/pages/{$page->id}/duplicate")
+            ->assertForbidden();
+    }
+
+    public function test_duplicate_preserves_parent_id(): void
+    {
+        // Arrange
+        $user   = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $parent = Page::factory()->create(['title' => 'Parent Page']);
+        $page   = Page::factory()->create(['title' => 'Child Page', 'parent_id' => $parent->id]);
+
+        // Act
+        $this->actingAs($user)->post("/admin/pages/{$page->id}/duplicate");
+
+        // Assert
+        $copy = Page::where('title', 'Child Page (Copy)')->first();
+        $this->assertNotNull($copy);
+        $this->assertEquals($parent->id, $copy->parent_id);
+    }
+
+    public function test_duplicate_sets_draft_status_even_when_original_is_published(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $page = Page::factory()->create([
+            'title'        => 'Live Page',
+            'status'       => ContentStatus::Published,
+            'published_at' => now(),
+        ]);
+
+        // Act
+        $this->actingAs($user)->post("/admin/pages/{$page->id}/duplicate");
+
+        // Assert
+        $copy = Page::where('title', 'Live Page (Copy)')->first();
+        $this->assertNotNull($copy);
+        $this->assertEquals(ContentStatus::Draft, $copy->status);
+        $this->assertNull($copy->published_at);
+    }
 }

--- a/laravel/tests/Feature/Admin/PostControllerTest.php
+++ b/laravel/tests/Feature/Admin/PostControllerTest.php
@@ -762,4 +762,102 @@ class PostControllerTest extends TestCase
             ->delete("/admin/posts/{$post->id}/force-delete")
             ->assertForbidden();
     }
+
+    // ─── duplicate ────────────────────────────────────────────────────────────
+
+    public function test_super_admin_can_duplicate_any_post(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $post = Post::factory()->create(['title' => 'Original Post', 'status' => ContentStatus::Published]);
+
+        // Act
+        $response = $this->actingAs($user)->post("/admin/posts/{$post->id}/duplicate");
+
+        // Assert
+        $copy = Post::where('title', 'Original Post (Copy)')->first();
+        $this->assertNotNull($copy);
+        $this->assertEquals(ContentStatus::Draft, $copy->status);
+        $this->assertNull($copy->published_at);
+        $this->assertEquals($user->id, $copy->user_id);
+        $response->assertRedirect("/admin/posts/{$copy->id}/edit");
+    }
+
+    public function test_editor_can_duplicate_own_post(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::Editor]);
+        $post = Post::factory()->create(['user_id' => $user->id, 'title' => 'My Post']);
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->post("/admin/posts/{$post->id}/duplicate")
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('posts', ['title' => 'My Post (Copy)', 'user_id' => $user->id]);
+    }
+
+    public function test_editor_can_duplicate_another_editors_post(): void
+    {
+        // Arrange
+        $editor = User::factory()->create(['role' => UserRole::Editor]);
+        $owner  = User::factory()->create(['role' => UserRole::Editor]);
+        $post   = Post::factory()->create(['user_id' => $owner->id, 'title' => 'Shared Post']);
+
+        // Act + Assert — duplicate uses create permission, not ownership
+        $this->actingAs($editor)
+            ->post("/admin/posts/{$post->id}/duplicate")
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('posts', ['title' => 'Shared Post (Copy)', 'user_id' => $editor->id]);
+    }
+
+    public function test_viewer_cannot_duplicate_post(): void
+    {
+        // Arrange
+        $viewer = User::factory()->create(['role' => UserRole::Viewer]);
+        $post   = Post::factory()->create();
+
+        // Act + Assert
+        $this->actingAs($viewer)
+            ->post("/admin/posts/{$post->id}/duplicate")
+            ->assertForbidden();
+    }
+
+    public function test_duplicate_copies_tags(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $tags = Tag::factory()->count(2)->create();
+        $post = Post::factory()->create(['title' => 'Tagged Post']);
+        $post->tags()->sync($tags->pluck('id'));
+
+        // Act
+        $this->actingAs($user)->post("/admin/posts/{$post->id}/duplicate");
+
+        // Assert
+        $copy = Post::where('title', 'Tagged Post (Copy)')->with('tags')->first();
+        $this->assertNotNull($copy);
+        $this->assertEqualsCanonicalizing($tags->pluck('id')->toArray(), $copy->tags->pluck('id')->toArray());
+    }
+
+    public function test_duplicate_sets_draft_status_even_when_original_is_published(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $post = Post::factory()->create([
+            'title'        => 'Live Post',
+            'status'       => ContentStatus::Published,
+            'published_at' => now(),
+        ]);
+
+        // Act
+        $this->actingAs($user)->post("/admin/posts/{$post->id}/duplicate");
+
+        // Assert
+        $copy = Post::where('title', 'Live Post (Copy)')->first();
+        $this->assertNotNull($copy);
+        $this->assertEquals(ContentStatus::Draft, $copy->status);
+        $this->assertNull($copy->published_at);
+    }
 }

--- a/plan.md
+++ b/plan.md
@@ -83,7 +83,7 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 | ✅     | [#159](https://github.com/Three-Hoops/Hoops-CMS/issues/159) | Register admin resource routes for content types                      | `content`, `enhancement` |
 | ✅     | [#160](https://github.com/Three-Hoops/Hoops-CMS/issues/160) | Build Vue pages and shared components for content management          | `content`, `enhancement` |
 | ✅     | [#76](https://github.com/Three-Hoops/Hoops-CMS/issues/76)   | Add parent_id to pages table for hierarchical page structure          | `content`, `enhancement` |
-| ⬜     | [#85](https://github.com/Three-Hoops/Hoops-CMS/issues/85)   | Add duplicate action for posts and pages                              | `content`, `enhancement` |
+| ✅     | [#85](https://github.com/Three-Hoops/Hoops-CMS/issues/85)   | Add duplicate action for posts and pages                              | `content`, `enhancement` |
 | ⬜     | [#65](https://github.com/Three-Hoops/Hoops-CMS/issues/65)   | Add per-post and per-page Open Graph / social meta fields             | `content`, `enhancement` |
 | ⬜     | [#69](https://github.com/Three-Hoops/Hoops-CMS/issues/69)   | Add featured/pinned flag to posts                                     | `content`, `enhancement` |
 | ✅     | [#40](https://github.com/Three-Hoops/Hoops-CMS/issues/40)   | Add database indexes to content migrations                            | `performance`            |


### PR DESCRIPTION
Closes #85

## Summary

- Adds a **Duplicate** button to the Posts and Pages index tables (non-trash view only)
- Duplicates copy all content fields, preserve tags (posts) and `parent_id` (pages), and are always created as `Draft` owned by the acting user
- Any editor can duplicate any post/page (uses `create` permission, not ownership); viewers are blocked

## Test plan

- [ ] `php artisan test --filter=duplicate` — 12 PHP tests pass
- [ ] `pnpm test` — 6 new Vitest tests pass, no regressions
- [ ] Visit `/admin/posts`, click Duplicate → redirected to edit page for new post titled `"Original (Copy)"` with Draft status and tags copied
- [ ] Visit `/admin/pages`, click Duplicate → same behaviour, parent preserved
- [ ] Confirm Duplicate button is absent in Trash view
- [ ] Log in as Viewer → Duplicate returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)