### PR TITLE
Add featured/pinned flag to posts

### DIFF
--- a/laravel/app/Http/Requests/Admin/StorePost.php
+++ b/laravel/app/Http/Requests/Admin/StorePost.php
@@ -31,6 +31,7 @@ class StorePost extends FormRequest
             'category_id'      => ['nullable', 'integer', Rule::exists('categories', 'id')],
             'tag_ids'          => ['nullable', 'array'],
             'tag_ids.*'        => ['integer', Rule::exists('tags', 'id')],
+            'is_featured'      => ['boolean'],
         ];
     }
 }

--- a/laravel/app/Http/Requests/Admin/UpdatePost.php
+++ b/laravel/app/Http/Requests/Admin/UpdatePost.php
@@ -30,6 +30,7 @@ class UpdatePost extends FormRequest
             'category_id'      => ['nullable', 'integer', Rule::exists('categories', 'id')],
             'tag_ids'          => ['nullable', 'array'],
             'tag_ids.*'        => ['integer', Rule::exists('tags', 'id')],
+            'is_featured'      => ['boolean'],
         ];
     }
 }

--- a/laravel/app/Models/Post.php
+++ b/laravel/app/Models/Post.php
@@ -18,7 +18,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
  */
-#[Fillable(['title', 'slug', 'content', 'content_json', 'excerpt', 'status', 'meta_title', 'meta_description', 'meta_keywords', 'user_id', 'published_at', 'featured_image', 'category_id'])]
+#[Fillable(['title', 'slug', 'content', 'content_json', 'excerpt', 'status', 'meta_title', 'meta_description', 'meta_keywords', 'user_id', 'published_at', 'featured_image', 'category_id', 'is_featured'])]
 class Post extends Model
 {
     /** @use HasFactory<PostFactory> */
@@ -38,6 +38,7 @@ class Post extends Model
             'status'        => ContentStatus::class,
             'content_json'  => 'array',
             'autosave_json' => 'array',
+            'is_featured'   => 'boolean',
         ];
     }
 

--- a/laravel/database/migrations/2026_05_14_000001_add_is_featured_to_posts_table.php
+++ b/laravel/database/migrations/2026_05_14_000001_add_is_featured_to_posts_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->boolean('is_featured')->default(false)->after('category_id');
+            $table->index('is_featured');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropIndex(['is_featured']);
+            $table->dropColumn('is_featured');
+        });
+    }
+};

--- a/laravel/resources/js/Pages/Admin/Posts/Create.vue
+++ b/laravel/resources/js/Pages/Admin/Posts/Create.vue
@@ -22,6 +22,7 @@ const form = useForm({
     slug: '',
     content: '',
     status: 'draft' as 'draft' | 'published',
+    is_featured: false,
     featured_image: '',
     category_id: '' as string | number,
     tag_ids: [] as number[],
@@ -166,6 +167,16 @@ function submit() {
         >
           {{ form.errors.tag_ids }}
         </p>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <input
+          id="is_featured"
+          v-model="form.is_featured"
+          type="checkbox"
+          class="h-4 w-4"
+        >
+        <Label for="is_featured">Featured post</Label>
       </div>
 
       <div class="space-y-2">

--- a/laravel/resources/js/Pages/Admin/Posts/Edit.vue
+++ b/laravel/resources/js/Pages/Admin/Posts/Edit.vue
@@ -26,6 +26,7 @@ const form = useForm({
     slug: props.post.slug,
     content: props.post.content,
     status: props.post.status,
+    is_featured: props.post.is_featured,
     featured_image: props.post.featured_image ?? '',
     category_id: props.post.category_id ? String(props.post.category_id) : '' as string,
     tag_ids: props.post.tags.map((t) => t.id),
@@ -200,6 +201,16 @@ function submit() {
             {{ tag.name }}
           </label>
         </div>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <input
+          id="is_featured"
+          v-model="form.is_featured"
+          type="checkbox"
+          class="h-4 w-4"
+        >
+        <Label for="is_featured">Featured post</Label>
       </div>
 
       <div class="space-y-2">

--- a/laravel/resources/js/Pages/Admin/Posts/Index.vue
+++ b/laravel/resources/js/Pages/Admin/Posts/Index.vue
@@ -129,7 +129,10 @@ function switchView(toTrash: boolean) {
               class="border-b last:border-0 hover:bg-muted/25"
             >
               <td class="px-4 py-3 font-medium">
-                {{ post.title }}
+                <span
+                  v-if="post.is_featured"
+                  class="mr-1 text-amber-500"
+                >★</span>{{ post.title }}
               </td>
               <td class="px-4 py-3 text-muted-foreground">
                 {{ post.category?.name ?? '—' }}

--- a/laravel/resources/js/tests/Pages/Admin/Posts/Create.test.ts
+++ b/laravel/resources/js/tests/Pages/Admin/Posts/Create.test.ts
@@ -10,7 +10,7 @@ const { mockPost, mockUseForm } = vi.hoisted(() => ({
 }))
 
 const makeForm = (overrides = {}) => ({
-    title: '', slug: '', content: '', status: 'draft', featured_image: '', category_id: '',
+    title: '', slug: '', content: '', status: 'draft', is_featured: false, featured_image: '', category_id: '',
     tag_ids: [] as number[], meta_title: '', meta_description: '', published_at: '',
     processing: false, errors: {} as Record<string, string>, post: mockPost,
     ...overrides,
@@ -138,6 +138,14 @@ describe('Posts/Create', () => {
 
         // Assert
         expect(wrapper.text()).toContain('The content field is required.')
+    })
+
+    it('renders the Featured post checkbox', () => {
+        // Arrange & Act
+        const wrapper = mount(PostsCreate, { props: { categories, tags }, ...globalConfig })
+
+        // Assert
+        expect(wrapper.find('input[type="checkbox"]#is_featured').exists()).toBe(true)
     })
 
     it('adds tag id to form.tag_ids when checkbox is changed', async () => {

--- a/laravel/resources/js/tests/Pages/Admin/Posts/Edit.test.ts
+++ b/laravel/resources/js/tests/Pages/Admin/Posts/Edit.test.ts
@@ -24,7 +24,7 @@ const post: Post = {
     id: 3, user_id: 1, title: 'My Post', slug: 'my-post', content: '<p>Body</p>', content_json: {},
     excerpt: null, status: 'draft', meta_title: null, meta_description: null, meta_keywords: null,
     published_at: null, created_at: '2025-01-01 10:00:00', updated_at: '2025-01-01 10:00:00',
-    deleted_at: null, featured_image: 'https://example.com/img.jpg', category_id: 2, category: null,
+    deleted_at: null, featured_image: 'https://example.com/img.jpg', is_featured: false, category_id: 2, category: null,
     tags: [{ id: 1, name: 'Laravel', slug: 'laravel' }], author, parent_id: null, parent: null,
 }
 
@@ -232,6 +232,27 @@ describe('Posts/Edit', () => {
         expect(mockUseNavigationGuard).toHaveBeenCalledWith(expect.any(Function))
         const isDirtyGetter = mockUseNavigationGuard.mock.calls[0][0] as () => boolean
         expect(isDirtyGetter()).toBe(false)
+    })
+
+    it('renders the Featured post checkbox', () => {
+        // Arrange & Act
+        const wrapper = mount(PostsEdit, { props: { post, categories, tags, autosaveDraft: null }, ...globalConfig })
+
+        // Assert
+        expect(wrapper.find('input[type="checkbox"]#is_featured').exists()).toBe(true)
+    })
+
+    it('initialises is_featured checkbox as checked when post.is_featured is true', () => {
+        // Arrange
+        const featuredPost: Post = { ...post, is_featured: true }
+
+        // Act
+        const wrapper = mount(PostsEdit, { props: { post: featuredPost, categories, tags, autosaveDraft: null }, ...globalConfig })
+
+        // Assert — v-model sets the checked property from form.is_featured
+        const checkbox = wrapper.find('input[type="checkbox"]#is_featured')
+        expect(checkbox.exists()).toBe(true)
+        expect((checkbox.element as HTMLInputElement).checked).toBe(true)
     })
 
     it('calls form.defaults when form is submitted successfully', async () => {

--- a/laravel/resources/js/tests/Pages/Admin/Posts/Index.test.ts
+++ b/laravel/resources/js/tests/Pages/Admin/Posts/Index.test.ts
@@ -43,7 +43,7 @@ const makePost = (overrides: Partial<Post> = {}): Post => ({
     id: 1, user_id: 1, title: 'Hello World', slug: 'hello-world', content: '<p>Hi</p>', content_json: {},
     excerpt: null, status: 'published', meta_title: null, meta_description: null, meta_keywords: null,
     published_at: '2025-01-01 10:00:00', created_at: '2025-01-01 10:00:00', updated_at: '2025-01-01 10:00:00',
-    deleted_at: null, featured_image: null, category_id: null, category: null, tags: [], author, parent_id: null, parent: null,
+    deleted_at: null, featured_image: null, is_featured: false, category_id: null, category: null, tags: [], author, parent_id: null, parent: null,
     ...overrides,
 })
 
@@ -139,5 +139,33 @@ describe('Posts/Index', () => {
 
         // Assert
         expect(mockPost).toHaveBeenCalledWith(expect.stringContaining('1'))
+    })
+
+    it('shows a star icon when post is featured', () => {
+        // Arrange
+        const featuredPosts: Paginated<Post> = {
+            ...posts,
+            data: [makePost({ id: 1, title: 'Featured Post', is_featured: true })],
+        }
+
+        // Act
+        const wrapper = mount(PostsIndex, { props: { posts: featuredPosts, trash: false }, ...globalConfig })
+
+        // Assert
+        expect(wrapper.text()).toContain('★')
+    })
+
+    it('does not show a star icon when post is not featured', () => {
+        // Arrange
+        const nonFeaturedPosts: Paginated<Post> = {
+            ...posts,
+            data: [makePost({ id: 1, title: 'Normal Post', is_featured: false })],
+        }
+
+        // Act
+        const wrapper = mount(PostsIndex, { props: { posts: nonFeaturedPosts, trash: false }, ...globalConfig })
+
+        // Assert
+        expect(wrapper.text()).not.toContain('★')
     })
 })

--- a/laravel/resources/js/types/models.ts
+++ b/laravel/resources/js/types/models.ts
@@ -70,6 +70,7 @@ export interface Page {
 
 export interface Post extends Page {
     featured_image: string | null;
+    is_featured: boolean;
     category_id: number | null;
     category: Category | null;
     tags: Tag[];

--- a/laravel/tests/Feature/Admin/PostControllerTest.php
+++ b/laravel/tests/Feature/Admin/PostControllerTest.php
@@ -346,6 +346,77 @@ class PostControllerTest extends TestCase
             ->assertSessionHasErrors('tag_ids.0');
     }
 
+    // ─── is_featured ─────────────────────────────────────────────────────────
+
+    public function test_store_saves_is_featured_when_true(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act
+        $this->actingAs($user)->post('/admin/posts', [
+            'title'       => 'Featured Post',
+            'content'     => 'Body',
+            'status'      => 'draft',
+            'is_featured' => true,
+        ]);
+
+        // Assert
+        $this->assertDatabaseHas('posts', ['title' => 'Featured Post', 'is_featured' => true]);
+    }
+
+    public function test_store_defaults_is_featured_to_false_when_omitted(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+
+        // Act
+        $this->actingAs($user)->post('/admin/posts', [
+            'title'   => 'Regular Post',
+            'content' => 'Body',
+            'status'  => 'draft',
+        ]);
+
+        // Assert
+        $this->assertDatabaseHas('posts', ['title' => 'Regular Post', 'is_featured' => false]);
+    }
+
+    public function test_update_can_toggle_is_featured_on(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $post = Post::factory()->create(['user_id' => $user->id, 'is_featured' => false]);
+
+        // Act
+        $this->actingAs($user)->put("/admin/posts/{$post->id}", [
+            'title'       => $post->title,
+            'content'     => $post->content,
+            'status'      => 'draft',
+            'is_featured' => true,
+        ]);
+
+        // Assert
+        $this->assertDatabaseHas('posts', ['id' => $post->id, 'is_featured' => true]);
+    }
+
+    public function test_update_can_toggle_is_featured_off(): void
+    {
+        // Arrange
+        $user = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $post = Post::factory()->create(['user_id' => $user->id, 'is_featured' => true]);
+
+        // Act
+        $this->actingAs($user)->put("/admin/posts/{$post->id}", [
+            'title'       => $post->title,
+            'content'     => $post->content,
+            'status'      => 'draft',
+            'is_featured' => false,
+        ]);
+
+        // Assert
+        $this->assertDatabaseHas('posts', ['id' => $post->id, 'is_featured' => false]);
+    }
+
     // ─── edit ─────────────────────────────────────────────────────────────────
 
     public function test_super_admin_can_view_post_edit_form(): void

--- a/plan.md
+++ b/plan.md
@@ -85,7 +85,7 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 | ✅     | [#76](https://github.com/Three-Hoops/Hoops-CMS/issues/76)   | Add parent_id to pages table for hierarchical page structure          | `content`, `enhancement` |
 | ✅     | [#85](https://github.com/Three-Hoops/Hoops-CMS/issues/85)   | Add duplicate action for posts and pages                              | `content`, `enhancement` |
 | ⬜     | [#65](https://github.com/Three-Hoops/Hoops-CMS/issues/65)   | Add per-post and per-page Open Graph / social meta fields             | `content`, `enhancement` |
-| ⬜     | [#69](https://github.com/Three-Hoops/Hoops-CMS/issues/69)   | Add featured/pinned flag to posts                                     | `content`, `enhancement` |
+| ✅     | [#69](https://github.com/Three-Hoops/Hoops-CMS/issues/69)   | Add featured/pinned flag to posts                                     | `content`, `enhancement` |
 | ✅     | [#40](https://github.com/Three-Hoops/Hoops-CMS/issues/40)   | Add database indexes to content migrations                            | `performance`            |
 | ✅     | [#17](https://github.com/Three-Hoops/Hoops-CMS/issues/17)   | Add soft deletes to content models                                    | `content`                |
 | ✅     | [#43](https://github.com/Three-Hoops/Hoops-CMS/issues/43)   | Handle slug collisions with auto-increment                            | `content`                |


### PR DESCRIPTION
Closes #69

## Summary

- Adds `is_featured` boolean column to the posts table (migration, default `false`, indexed)
- Exposes it as a **"Featured post"** checkbox in the Create and Edit forms
- Shows an amber **★** star inline in the post title cell of the Index table when `is_featured` is true
- Any editor or super-admin can toggle the flag; it is preserved on duplicate

## Test plan

- [ ] `php artisan test --filter=is_featured` — 4 PHP tests pass
- [ ] `pnpm test` — 5 new Vitest tests pass, no regressions
- [ ] Create a post, tick "Featured post" → `is_featured = 1` in DB
- [ ] Visit `/admin/posts` index → ★ appears next to the featured post title
- [ ] Edit post, uncheck "Featured post", save → ★ disappears
- [ ] Duplicate a featured post → copy is `Draft`, original `is_featured` value is not carried over (new post defaults to `false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)