### PR TITLE
Add trash view and restore for soft-deleted content

### DIFF
--- a/laravel/tests/Feature/Admin/PageControllerTest.php
+++ b/laravel/tests/Feature/Admin/PageControllerTest.php
@@ -70,6 +70,25 @@ class PageControllerTest extends TestCase
         $this->get('/admin/pages')->assertRedirect(route('admin.login'));
     }
 
+    public function test_trash_index_shows_only_soft_deleted_pages(): void
+    {
+        // Arrange
+        $user    = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $active  = Page::factory()->create(['user_id' => $user->id]);
+        $deleted = Page::factory()->create(['user_id' => $user->id]);
+        $deleted->delete();
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->get('/admin/pages?trash=1')
+            ->assertInertia(fn ($page) => $page
+                ->component('Admin/Pages/Index')
+                ->where('trash', true)
+                ->has('pages.data', 1)
+                ->where('pages.data.0.id', $deleted->id)
+            );
+    }
+
     // ─── create ───────────────────────────────────────────────────────────────
 
     public function test_super_admin_can_view_create_page_form(): void
@@ -612,6 +631,20 @@ class PageControllerTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_viewer_cannot_restore_page(): void
+    {
+        // Arrange
+        $viewer = User::factory()->create(['role' => UserRole::Viewer]);
+        $owner  = User::factory()->create(['role' => UserRole::Editor]);
+        $page   = Page::factory()->create(['user_id' => $owner->id]);
+        $page->delete();
+
+        // Act + Assert
+        $this->actingAs($viewer)
+            ->post("/admin/pages/{$page->id}/restore")
+            ->assertForbidden();
+    }
+
     // ─── forceDelete ──────────────────────────────────────────────────────────
 
     public function test_super_admin_can_force_delete_soft_deleted_page(): void
@@ -637,6 +670,20 @@ class PageControllerTest extends TestCase
 
         // Act + Assert
         $this->actingAs($user)
+            ->delete("/admin/pages/{$page->id}/force-delete")
+            ->assertForbidden();
+    }
+
+    public function test_viewer_cannot_force_delete_page(): void
+    {
+        // Arrange
+        $viewer = User::factory()->create(['role' => UserRole::Viewer]);
+        $owner  = User::factory()->create(['role' => UserRole::Editor]);
+        $page   = Page::factory()->create(['user_id' => $owner->id]);
+        $page->delete();
+
+        // Act + Assert
+        $this->actingAs($viewer)
             ->delete("/admin/pages/{$page->id}/force-delete")
             ->assertForbidden();
     }

--- a/laravel/tests/Feature/Admin/PostControllerTest.php
+++ b/laravel/tests/Feature/Admin/PostControllerTest.php
@@ -91,6 +91,25 @@ class PostControllerTest extends TestCase
         $this->actingAs($user)->get('/admin/posts')->assertOk();
     }
 
+    public function test_trash_index_shows_only_soft_deleted_posts(): void
+    {
+        // Arrange
+        $user    = User::factory()->create(['role' => UserRole::SuperAdmin]);
+        $active  = Post::factory()->create(['user_id' => $user->id]);
+        $deleted = Post::factory()->create(['user_id' => $user->id]);
+        $deleted->delete();
+
+        // Act + Assert
+        $this->actingAs($user)
+            ->get('/admin/posts?trash=1')
+            ->assertInertia(fn ($page) => $page
+                ->component('Admin/Posts/Index')
+                ->where('trash', true)
+                ->has('posts.data', 1)
+                ->where('posts.data.0.id', $deleted->id)
+            );
+    }
+
     // ─── create ───────────────────────────────────────────────────────────────
 
     public function test_super_admin_can_view_create_post_form(): void
@@ -819,6 +838,20 @@ class PostControllerTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_viewer_cannot_restore_post(): void
+    {
+        // Arrange
+        $viewer = User::factory()->create(['role' => UserRole::Viewer]);
+        $owner  = User::factory()->create(['role' => UserRole::Editor]);
+        $post   = Post::factory()->create(['user_id' => $owner->id]);
+        $post->delete();
+
+        // Act + Assert
+        $this->actingAs($viewer)
+            ->post("/admin/posts/{$post->id}/restore")
+            ->assertForbidden();
+    }
+
     // ─── forceDelete ──────────────────────────────────────────────────────────
 
     public function test_super_admin_can_force_delete_soft_deleted_post(): void
@@ -844,6 +877,20 @@ class PostControllerTest extends TestCase
 
         // Act + Assert
         $this->actingAs($user)
+            ->delete("/admin/posts/{$post->id}/force-delete")
+            ->assertForbidden();
+    }
+
+    public function test_viewer_cannot_force_delete_post(): void
+    {
+        // Arrange
+        $viewer = User::factory()->create(['role' => UserRole::Viewer]);
+        $owner  = User::factory()->create(['role' => UserRole::Editor]);
+        $post   = Post::factory()->create(['user_id' => $owner->id]);
+        $post->delete();
+
+        // Act + Assert
+        $this->actingAs($viewer)
             ->delete("/admin/posts/{$post->id}/force-delete")
             ->assertForbidden();
     }

--- a/plan.md
+++ b/plan.md
@@ -94,7 +94,7 @@ Issues are ordered by implementation sequence. Complete each stage before moving
 | ✅     | [#68](https://github.com/Three-Hoops/Hoops-CMS/issues/68)   | Add autosave for rich text editor to prevent data loss                | `content`, `enhancement` |
 | ✅     | [#110](https://github.com/Three-Hoops/Hoops-CMS/issues/110) | Warn users about unsaved changes before navigating away               | `content`, `enhancement` |
 | ⬜     | [#58](https://github.com/Three-Hoops/Hoops-CMS/issues/58)   | Bulk actions on content lists (publish, draft, delete)                | `content`, `enhancement` |
-| ⬜     | [#75](https://github.com/Three-Hoops/Hoops-CMS/issues/75)   | Add trash view and restore for soft-deleted content                   | `content`, `enhancement` |
+| ✅     | [#75](https://github.com/Three-Hoops/Hoops-CMS/issues/75)   | Add trash view and restore for soft-deleted content                   | `content`, `enhancement` |
 | ⬜     | [#32](https://github.com/Three-Hoops/Hoops-CMS/issues/32)   | Add draft preview for posts and pages                                 | `content`, `enhancement` |
 | ⬜     | [#72](https://github.com/Three-Hoops/Hoops-CMS/issues/72)   | Add language switcher UI to post and page edit forms                  | `content`, `enhancement` |
 | ⬜     | [#66](https://github.com/Three-Hoops/Hoops-CMS/issues/66)   | Write Vue component tests for admin UI components                     | `testing`                |


### PR DESCRIPTION
Closes #75

## Summary

- Trash view already fully implemented (backend controllers, routes, policies, and frontend All/Trash toggle UI) as part of earlier PRs
- Adds the missing PHP test coverage to complete the issue:
  - `test_trash_index_shows_only_soft_deleted_posts/pages` — verifies `?trash=1` returns only trashed records with `trash: true` prop
  - `test_viewer_cannot_restore_post/page` — viewer gets 403 on restore
  - `test_viewer_cannot_force_delete_post/page` — viewer gets 403 on force-delete

## Test plan

- [x] `php artisan test` — 278 tests passing
- [x] Trash index filter verified (active records excluded from `?trash=1` response)
- [x] Viewer permission gates verified for restore and force-delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)